### PR TITLE
docs: note python version required in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A flake8 extension that implements misc. lints
 
+Note: flake8-pie requires Python 3.6 or greater
+
 ## lints
 
 ### PIE781: Assign and Return


### PR DESCRIPTION
document python version required to run flake8-pie in readme

closes https://github.com/sbdchd/flake8-pie/issues/14