### PR TITLE
fix: broken crontab lint

### DIFF
--- a/flake8_pie.py
+++ b/flake8_pie.py
@@ -142,8 +142,7 @@ def is_invalid_celery_crontab(*, kwargs: List[ast.keyword]) -> bool:
         return True
 
     largest_index = max(
-        (CELERY_ARG_MAP[k] for k in keyword_args if CELERY_ARG_MAP.get(k)),
-        default=0
+        (CELERY_ARG_MAP[k] for k in keyword_args if CELERY_ARG_MAP.get(k)), default=0
     )
 
     for key in CELERY_LS[:largest_index]:

--- a/flake8_pie.py
+++ b/flake8_pie.py
@@ -138,8 +138,12 @@ CELERY_LS = ["minute", "hour", "day_of_week", "day_of_month", "month_of_year"]
 def is_invalid_celery_crontab(*, kwargs: List[ast.keyword]) -> bool:
     keyword_args = {k.arg for k in kwargs if k.arg is not None}
 
+    if not keyword_args:
+        return True
+
     largest_index = max(
-        CELERY_ARG_MAP[k] for k in keyword_args if CELERY_ARG_MAP.get(k)
+        (CELERY_ARG_MAP[k] for k in keyword_args if CELERY_ARG_MAP.get(k)),
+        default=0
     )
 
     for key in CELERY_LS[:largest_index]:

--- a/tests.py
+++ b/tests.py
@@ -274,6 +274,18 @@ crontab(month_of_year="*", day_of_month="*", hour="0,12", minute="*"),
 """,
             PIE784(lineno=2, col_offset=0),
         ),
+        (
+            """
+crontab(),
+""",
+            PIE784(lineno=2, col_offset=0),
+        ),
+        (
+            """
+crontab(minute="*/5")
+""",
+            None,
+        ),
     ],
 )
 def test_celery_crontab_named_args(code: str, expected: Optional[ErrorLoc]) -> None:


### PR DESCRIPTION
Case where no args are passed or only `minute` is passed wasn't handled
correctly