### PR TITLE
fix: checking of name based decorators

### DIFF
--- a/flake8_pie.py
+++ b/flake8_pie.py
@@ -109,7 +109,11 @@ def is_assign_and_return(func: ast.FunctionDef) -> Optional[ErrorLoc]:
 
 
 def has_name_kwarg(dec: ast.Call) -> bool:
-    return all(k.arg != "name" for k in dec.keywords)
+    return any(k.arg == "name" for k in dec.keywords)
+
+
+CELERY_SHARED_TASK_NAME = "shared_task"
+CELERY_TASK_NAME = "task"
 
 
 def is_celery_task_missing_name(func: ast.FunctionDef) -> Optional[ErrorLoc]:
@@ -118,15 +122,27 @@ def is_celery_task_missing_name(func: ast.FunctionDef) -> Optional[ErrorLoc]:
     """
     if func.decorator_list:
         for dec in func.decorator_list:
+            if (
+                isinstance(dec, ast.Attribute)
+                and isinstance(dec.value, ast.Name)
+                and dec.attr == CELERY_TASK_NAME
+            ):
+                return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
+            if isinstance(dec, ast.Name) and dec.id == CELERY_SHARED_TASK_NAME:
+                return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
             if isinstance(dec, ast.Call):
-                if isinstance(dec.func, ast.Name):
-                    if dec.func.id == "shared_task":
-                        if has_name_kwarg(dec):
-                            return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
-                if isinstance(dec.func, ast.Attribute):
-                    if dec.func.attr == "task":
-                        if has_name_kwarg(dec):
-                            return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
+                if (
+                    isinstance(dec.func, ast.Name)
+                    and dec.func.id == CELERY_SHARED_TASK_NAME
+                    and not has_name_kwarg(dec)
+                ):
+                    return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
+                if (
+                    isinstance(dec.func, ast.Attribute)
+                    and dec.func.attr == CELERY_TASK_NAME
+                    and not has_name_kwarg(dec)
+                ):
+                    return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
     return None
 
 

--- a/tests.py
+++ b/tests.py
@@ -226,6 +226,22 @@ def foo():
 """,
             None,
         ),
+        (
+            """
+@shared_task
+def foo():
+    pass
+""",
+            PIE783(lineno=2, col_offset=1),
+        ),
+        (
+            """
+@app.task
+def bar():
+    pass
+""",
+            PIE783(lineno=2, col_offset=1),
+        ),
     ],
 )
 def test_celery_task_name_lint(code: str, expected: Optional[ErrorLoc]) -> None:


### PR DESCRIPTION
Previously @shared_task or @app.task weren't checked. Only called
decorators like @shared_task() were.