### PR TITLE
cut: f-string lint as it had false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,6 @@ def foo():
    return x
 ```
 
-### PIE782: No Pointless F Strings
-
-Warn about usage of f-string without templated values.
-
-#### examples
-
-```python
-x = (
-    f"foo {y}", # ok
-    f"bar" # error
-)
-```
-
 ### PIE783: Celery tasks should have explicit names.
 
 Warn about [Celery](https://pypi.org/project/celery/) task definitions that don't have explicit names.

--- a/flake8_pie.py
+++ b/flake8_pie.py
@@ -50,22 +50,8 @@ class Flake8PieVisitor(ast.NodeVisitor):
 
         self.generic_visit(node)
 
-    def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
-        error = is_pointless_f_string(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: errors={self.errors}>"
-
-
-def is_pointless_f_string(node: ast.JoinedStr) -> Optional[ErrorLoc]:
-    for value in node.values:
-        if isinstance(value, ast.FormattedValue):
-            return None
-    return PIE782(lineno=node.lineno, col_offset=node.col_offset)
 
 
 def get_assign_target_id(stmt: ast.stmt) -> Optional[str]:
@@ -259,13 +245,6 @@ class Flake8PieCheck:
 PIE781 = partial(
     ErrorLoc,
     message="PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.",
-    type=Flake8PieCheck,
-)
-
-
-PIE782 = partial(
-    ErrorLoc,
-    message="PIE782: Unnecessary f-string. You can safely remove the `f` prefix.",
     type=Flake8PieCheck,
 )
 

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,6 @@ import pytest
 
 from flake8_pie import (
     PIE781,
-    PIE782,
     PIE783,
     PIE784,
     PIE785,
@@ -114,32 +113,6 @@ def test_is_assign_and_return(
 
     expected_errors = [expected] if expected is not None else []
 
-    assert list(Flake8PieCheck(node).run()) == expected_errors, reason
-
-
-@pytest.mark.parametrize(
-    "func,expected,reason",
-    [
-        (
-            """
-x = (
-    f"foo {y}",
-    f"bar"
-)""",
-            PIE782(lineno=4, col_offset=4),
-            "f string with no templates",
-        ),
-        ("f'foo {y}'", None, "used template"),
-    ],
-)
-def test_no_pointless_f_strings(
-    func: str, expected: Optional[ErrorLoc], reason: str
-) -> None:
-    node = ast.parse(func)
-
-    assert isinstance(node, ast.Module)
-
-    expected_errors = [expected] if expected else []
     assert list(Flake8PieCheck(node).run()) == expected_errors, reason
 
 


### PR DESCRIPTION
Turns out the AST of f-strings was more complicated than the examples
I initially imagined. Fixing the rule will is likely more annoying than
simply removing it.

rel: https://github.com/sbdchd/flake8-pie/issues/24