### PR TITLE
ref: combine visitors

### DIFF
--- a/flake8_pie/__init__.py
+++ b/flake8_pie/__init__.py
@@ -1,24 +1,174 @@
 from __future__ import annotations
 
-from flake8_pie.pie781_assign_and_return import Flake8PieCheck781  # noqa: F401
-from flake8_pie.pie783_celery_explicit_names import Flake8PieCheck783  # noqa: F401
-from flake8_pie.pie784_celery_crontab_args import Flake8PieCheck784  # noqa: F401
-from flake8_pie.pie785_celery_require_tasks_expire import (  # noqa: F401
-    Flake8PieCheck785,
+import ast
+from typing import Iterable
+
+from flake8_pie.base import Error, Flake8Error
+from flake8_pie.pie781_assign_and_return import is_assign_and_return
+from flake8_pie.pie783_celery_explicit_names import is_celery_explicit_names
+from flake8_pie.pie784_celery_crontab_args import is_celery_crontab_args
+from flake8_pie.pie785_celery_require_tasks_expire import is_celery_require_tasks_expire
+from flake8_pie.pie786_precise_exception_handler import is_precise_exception_handler
+from flake8_pie.pie787_no_len_condition import is_no_len_condition
+from flake8_pie.pie788_no_bool_condition import is_no_bool_condition
+from flake8_pie.pie789_prefer_isinstance_type_compare import (
+    is_prefer_isinstance_type_compare,
 )
-from flake8_pie.pie786_precise_exception_handler import Flake8PieCheck786  # noqa: F401
-from flake8_pie.pie787_no_len_condition import Flake8PieCheck787  # noqa: F401
-from flake8_pie.pie788_no_bool_condition import Flake8PieCheck788  # noqa: F401
-from flake8_pie.pie789_prefer_isinstance_type_compare import (  # noqa: F401
-    Flake8PieCheck789,
+from flake8_pie.pie790_no_unnecessary_pass import is_no_unnecessary_pass
+from flake8_pie.pie791_no_pointless_statements import is_no_pointless_statements
+from flake8_pie.pie792_no_inherit_object import is_no_inherit_object
+from flake8_pie.pie793_prefer_dataclass import is_prefer_dataclass
+from flake8_pie.pie794_dupe_class_field_definitions import (
+    is_dupe_class_field_definition,
 )
-from flake8_pie.pie790_no_unnecessary_pass import Flake8PieCheck790  # noqa: F401
-from flake8_pie.pie791_no_pointless_statements import Flake8PieCheck791  # noqa: F401
-from flake8_pie.pie792_no_inherit_object import Flake8PieCheck792  # noqa: F401
-from flake8_pie.pie793_prefer_dataclass import Flake8PieCheck793  # noqa: F401
-from flake8_pie.pie794_dupe_class_field_definitions import (  # noqa: F401
-    Flake8PieCheck794,
-)
-from flake8_pie.pie795_prefer_stdlib_enums import Flake8PieCheck795  # noqa: F401
-from flake8_pie.pie796_prefer_unique_enums import Flake8PieCheck796  # noqa: F401
-from flake8_pie.pie797_no_unnecessary_if_expr import Flake8PieCheck797  # noqa: F401
+from flake8_pie.pie795_prefer_stdlib_enums import is_prefer_stdlib_enums
+from flake8_pie.pie796_prefer_unique_enums import is_prefer_unique_enum
+from flake8_pie.pie797_no_unnecessary_if_expr import is_no_unnecessary_if_expr
+
+
+class Flake8PieVisitor(ast.NodeVisitor):
+    def __init__(self, filename: str) -> None:
+        self.errors: list[Error] = []
+        self.filename = filename
+        self.inside_inheriting_cls_stack: list[bool] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # TODO(sbdchd): rename all these functions to `check_$number_$name` and
+        # have them return a list or maybe take in the list and mutate it
+        error = is_assign_and_return(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_celery_explicit_names(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_no_unnecessary_pass(node)
+        if error:
+            self.errors.append(error)
+
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+
+        error = is_no_unnecessary_pass(node)
+        if error:
+            self.errors.append(error)
+
+        self.errors += is_dupe_class_field_definition(node)
+
+        error = is_no_inherit_object(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_prefer_dataclass(node, self.inside_inheriting_cls_stack)
+        if error:
+            self.errors.append(error)
+
+        error = is_prefer_stdlib_enums(node, self.inside_inheriting_cls_stack)
+        if error:
+            self.errors.append(error)
+
+        error = is_prefer_unique_enum(node)
+        if error:
+            self.errors.append(error)
+
+        is_inheriting_cls = len(node.bases) > 0
+        self.inside_inheriting_cls_stack.append(is_inheriting_cls)
+        self.generic_visit(node)
+        self.inside_inheriting_cls_stack.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        error = is_celery_crontab_args(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_celery_require_tasks_expire(node)
+        if error:
+            self.errors.append(error)
+
+        self.generic_visit(node)
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        error = is_celery_require_tasks_expire(node)
+        if error:
+            self.errors.append(error)
+
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        error = is_precise_exception_handler(node)
+        if error:
+            self.errors.append(error)
+
+        self.generic_visit(node)
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        error = is_no_pointless_statements(node)
+        if error:
+            self.errors.append(error)
+        self.generic_visit(node)
+
+    def visit_If(self, node: ast.If) -> None:
+        error = is_no_len_condition(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_prefer_isinstance_type_compare(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_no_bool_condition(node)
+        if error:
+            self.errors.append(error)
+
+        self.generic_visit(node)
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        error = is_no_len_condition(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_no_bool_condition(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_prefer_isinstance_type_compare(node)
+        if error:
+            self.errors.append(error)
+
+        error = is_no_unnecessary_if_expr(node)
+        if error:
+            self.errors.append(error)
+
+        self.generic_visit(node)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: errors={self.errors}>"
+
+
+class Flake8PieCheck:
+    name = "flake8-pie"
+    version = "0.6.1"
+
+    def __init__(
+        self, tree: ast.Module, filename: str, *args: object, **kwargs: object
+    ) -> None:
+        self.filename = filename
+        self.tree = tree
+
+    def run(self) -> Iterable[Flake8Error]:
+        # When using flake8-pyi, skip the stub files.
+        if self.filename.endswith(".pyi"):
+            return
+
+        visitor = Flake8PieVisitor(self.filename)
+        visitor.visit(self.tree)
+
+        for err in visitor.errors:
+            yield Flake8Error(
+                message=err.message,
+                type=Flake8PieCheck,
+                lineno=err.lineno,
+                col_offset=err.col_offset,
+            )

--- a/flake8_pie/base.py
+++ b/flake8_pie/base.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import ast
-from typing import Iterable, NamedTuple
+from typing import NamedTuple
 
 
-class ErrorLoc(NamedTuple):
+class Flake8Error(NamedTuple):
     """
     location of the lint infraction
 
@@ -18,33 +17,7 @@ class ErrorLoc(NamedTuple):
     type: object
 
 
-class Flake8PieVisitor(ast.NodeVisitor):
-    def __init__(self, filename: str) -> None:
-        self.errors: list[ErrorLoc] = []
-        self.filename = filename
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}: errors={self.errors}>"
-
-
-class Flake8PieCheck:
-    name = "flake8-pie"
-    version = "0.6.1"
-
-    visitor: type[Flake8PieVisitor]
-
-    def __init__(
-        self, tree: ast.Module, filename: str, *args: object, **kwargs: object
-    ) -> None:
-        self.filename = filename
-        self.tree = tree
-
-    def run(self) -> Iterable[ErrorLoc]:
-        # When using flake8-pyi, skip the stub files.
-        if self.filename.endswith(".pyi"):
-            return
-        visitor = self.visitor(self.filename)
-
-        visitor.visit(self.tree)
-
-        yield from visitor.errors
+class Error(NamedTuple):
+    lineno: int
+    col_offset: int
+    message: str

--- a/flake8_pie/pie781_assign_and_return.py
+++ b/flake8_pie/pie781_assign_and_return.py
@@ -3,22 +3,10 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-class Vistor(Flake8PieVisitor):
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        """
-        run checker function and track error if found
-        """
-        error = is_assign_and_return(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
-
-def get_assign_target_id(stmt: ast.stmt) -> str | None:
+def _get_assign_target_id(stmt: ast.stmt) -> str | None:
     """
     We can have two types of assignments statements:
         - ast.Assign: usual assignment
@@ -37,7 +25,7 @@ def get_assign_target_id(stmt: ast.stmt) -> str | None:
     return None
 
 
-def is_assign_and_return(func: ast.FunctionDef) -> ErrorLoc | None:
+def is_assign_and_return(func: ast.FunctionDef) -> Error | None:
     """
     check a FunctionDef for assignment and return where a user assigns to a
     variable and returns that variable instead of just returning
@@ -49,7 +37,7 @@ def is_assign_and_return(func: ast.FunctionDef) -> ErrorLoc | None:
             return_stmt.value, ast.Name
         ):
             assign_stmt = func.body[-2]
-            assign_id = get_assign_target_id(assign_stmt)
+            assign_id = _get_assign_target_id(assign_stmt)
             if return_stmt.value.id == assign_id:
                 return PIE781(
                     lineno=return_stmt.lineno, col_offset=return_stmt.col_offset
@@ -58,12 +46,13 @@ def is_assign_and_return(func: ast.FunctionDef) -> ErrorLoc | None:
     return None
 
 
-class Flake8PieCheck781(Flake8PieCheck):
-    visitor = Vistor
+class PIE781_2:
+    message: str
+    lineno: int
+    col_offset: int
 
 
 PIE781 = partial(
-    ErrorLoc,
+    Error,
     message="PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.",
-    type=Flake8PieCheck781,
 )

--- a/flake8_pie/pie781_assign_and_return.py
+++ b/flake8_pie/pie781_assign_and_return.py
@@ -46,12 +46,6 @@ def is_assign_and_return(func: ast.FunctionDef) -> Error | None:
     return None
 
 
-class PIE781_2:
-    message: str
-    lineno: int
-    col_offset: int
-
-
 PIE781 = partial(
     Error,
     message="PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.",

--- a/flake8_pie/pie783_celery_explicit_names.py
+++ b/flake8_pie/pie783_celery_explicit_names.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
 def has_name_kwarg(dec: ast.Call) -> bool:
@@ -14,7 +14,7 @@ CELERY_SHARED_TASK_NAME = "shared_task"
 CELERY_TASK_NAME = "task"
 
 
-def _is_celery_task_missing_name(func: ast.FunctionDef) -> ErrorLoc | None:
+def is_celery_explicit_names(func: ast.FunctionDef) -> Error | None:
     """
     check if a Celery task definition is missing an explicit name.
     """
@@ -44,24 +44,4 @@ def _is_celery_task_missing_name(func: ast.FunctionDef) -> ErrorLoc | None:
     return None
 
 
-class GeneralFlake8PieVisitor(Flake8PieVisitor):
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        """
-        run checker function and track error if found
-        """
-        error = _is_celery_task_missing_name(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck783(Flake8PieCheck):
-    visitor = GeneralFlake8PieVisitor
-
-
-PIE783 = partial(
-    ErrorLoc,
-    message="PIE783: Celery tasks should have explicit names.",
-    type=Flake8PieCheck783,
-)
+PIE783 = partial(Error, message="PIE783: Celery tasks should have explicit names.")

--- a/flake8_pie/pie784_celery_crontab_args.py
+++ b/flake8_pie/pie784_celery_crontab_args.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 # from: github.com/celery/celery/blob/0736cff9d908c0519e07babe4de9c399c87cb32b/celery/schedules.py#L403
 CELERY_ARG_MAP = dict(minute=0, hour=1, day_of_week=2, day_of_month=3, month_of_year=4)
@@ -27,7 +27,7 @@ def _is_invalid_celery_crontab(*, kwargs: list[ast.keyword]) -> bool:
     return False
 
 
-def _is_loose_crontab_call(call: ast.Call) -> ErrorLoc | None:
+def is_celery_crontab_args(call: ast.Call) -> Error | None:
     """
     require that a user pass all time increments that are smaller than the
     highest one they specify.
@@ -42,21 +42,4 @@ def _is_loose_crontab_call(call: ast.Call) -> ErrorLoc | None:
     return None
 
 
-class GeneralFlake8PieVisitor(Flake8PieVisitor):
-    def visit_Call(self, node: ast.Call) -> None:
-        error = _is_loose_crontab_call(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck784(Flake8PieCheck):
-    visitor = GeneralFlake8PieVisitor
-
-
-PIE784 = partial(
-    ErrorLoc,
-    message="PIE784: Celery crontab is missing explicit arguments.",
-    type=Flake8PieCheck784,
-)
+PIE784 = partial(Error, message="PIE784: Celery crontab is missing explicit arguments.")

--- a/flake8_pie/pie786_precise_exception_handler.py
+++ b/flake8_pie/pie786_precise_exception_handler.py
@@ -1,27 +1,19 @@
+from __future__ import annotations
+
 import ast
 from functools import partial
-from typing import Any, List, Optional, cast
+from typing import Any, cast
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
-
-
-class Flake8Pie786Visitor(Flake8PieVisitor):
-    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
-        error = is_broad_except(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
+from flake8_pie.base import Error
 
 BAD_EXCEPT_IDS = {"BaseException", "Exception"}
 
 
-def is_bad_except_type(except_type: Optional[ast.Name]) -> bool:
+def _is_bad_except_type(except_type: ast.Name | None) -> bool:
     return except_type is None or except_type.id in BAD_EXCEPT_IDS
 
 
-def has_bad_control_flow(nodes: List[ast.stmt]) -> bool:
+def _has_bad_control_flow(nodes: list[ast.stmt]) -> bool:
     """
     Check if `return`, `break` or `continue` exists in node tree.
 
@@ -35,41 +27,35 @@ def has_bad_control_flow(nodes: List[ast.stmt]) -> bool:
         if (
             hasattr(node, "body")
             and isinstance(cast(Any, node).body, list)
-            and has_bad_control_flow(cast(Any, node).body)
+            and _has_bad_control_flow(cast(Any, node).body)
         ):
             return True
     return False
 
 
-def body_has_raise(except_body: List[ast.stmt]) -> bool:
+def _body_has_raise(except_body: list[ast.stmt]) -> bool:
     for node in except_body:
         if isinstance(node, ast.Raise):
             return True
     return False
 
 
-def is_broad_except(node: ast.ExceptHandler) -> Optional[ErrorLoc]:
+def is_precise_exception_handler(node: ast.ExceptHandler) -> Error | None:
     """
     ensure try...except is not called with Exception, BaseException, or no argument
     """
-    if body_has_raise(node.body) and not has_bad_control_flow(node.body):
+    if _body_has_raise(node.body) and not _has_bad_control_flow(node.body):
         return None
     if isinstance(node.type, ast.Tuple):
         for elt in node.type.elts:
-            if (isinstance(elt, ast.Name) or elt is None) and is_bad_except_type(elt):
+            if (isinstance(elt, ast.Name) or elt is None) and _is_bad_except_type(elt):
                 return PIE786(lineno=elt.lineno, col_offset=elt.col_offset)
         return None
-    if (isinstance(node.type, ast.Name) or node.type is None) and is_bad_except_type(
+    if (isinstance(node.type, ast.Name) or node.type is None) and _is_bad_except_type(
         node.type
     ):
         return PIE786(lineno=node.lineno, col_offset=node.col_offset)
     return None
 
 
-class Flake8PieCheck786(Flake8PieCheck):
-    visitor = Flake8Pie786Visitor
-
-
-PIE786 = partial(
-    ErrorLoc, message="PIE786: Use precise exception handlers.", type=Flake8PieCheck786
-)
+PIE786 = partial(Error, message="PIE786: Use precise exception handlers.")

--- a/flake8_pie/pie787_no_len_condition.py
+++ b/flake8_pie/pie787_no_len_condition.py
@@ -1,34 +1,19 @@
+from __future__ import annotations
+
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 from flake8_pie.utils import is_if_test_func_call
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_If(self, node: ast.If) -> None:
-        if is_if_test_func_call(node=node, func_name="len"):
-            self.errors.append(
-                PIE787(lineno=node.test.lineno, col_offset=node.test.col_offset)
-            )
-
-        self.generic_visit(node)
-
-    def visit_IfExp(self, node: ast.IfExp) -> None:
-        if is_if_test_func_call(node=node, func_name="len"):
-            self.errors.append(
-                PIE787(lineno=node.test.lineno, col_offset=node.test.col_offset)
-            )
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck787(Flake8PieCheck):
-    visitor = Visitor
+def is_no_len_condition(node: ast.If | ast.IfExp) -> Error | None:
+    if is_if_test_func_call(node=node, func_name="len"):
+        return PIE787(lineno=node.test.lineno, col_offset=node.test.col_offset)
+    return None
 
 
 PIE787 = partial(
-    ErrorLoc,
+    Error,
     message="PIE787: no-len-condition: Remove len() call or compare against a scalar.",
-    type=Flake8PieCheck787,
 )

--- a/flake8_pie/pie788_no_bool_condition.py
+++ b/flake8_pie/pie788_no_bool_condition.py
@@ -1,34 +1,18 @@
+from __future__ import annotations
+
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 from flake8_pie.utils import is_if_test_func_call
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_If(self, node: ast.If) -> None:
-        if is_if_test_func_call(node=node, func_name="bool"):
-            self.errors.append(
-                PIE788(lineno=node.test.lineno, col_offset=node.test.col_offset)
-            )
-
-        self.generic_visit(node)
-
-    def visit_IfExp(self, node: ast.IfExp) -> None:
-        if is_if_test_func_call(node=node, func_name="bool"):
-            self.errors.append(
-                PIE788(lineno=node.test.lineno, col_offset=node.test.col_offset)
-            )
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck788(Flake8PieCheck):
-    visitor = Visitor
+def is_no_bool_condition(node: ast.If | ast.IfExp) -> Error | None:
+    if is_if_test_func_call(node=node, func_name="bool"):
+        return PIE788(lineno=node.test.lineno, col_offset=node.test.col_offset)
+    return None
 
 
 PIE788 = partial(
-    ErrorLoc,
-    message="PIE788: no-bool-condition: Remove unnecessary bool() call.",
-    type=Flake8PieCheck788,
+    Error, message="PIE788: no-bool-condition: Remove unnecessary bool() call."
 )

--- a/flake8_pie/pie789_prefer_isinstance_type_compare.py
+++ b/flake8_pie/pie789_prefer_isinstance_type_compare.py
@@ -1,30 +1,23 @@
+from __future__ import annotations
+
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_If(self, node: ast.If) -> None:
-        if (
-            isinstance(node.test, ast.Compare)
-            and isinstance(node.test.left, ast.Call)
-            and isinstance(node.test.left.func, ast.Name)
-            and node.test.left.func.id == "type"
-        ):
-            self.errors.append(
-                PIE789(lineno=node.test.lineno, col_offset=node.test.col_offset)
-            )
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck789(Flake8PieCheck):
-    visitor = Visitor
+def is_prefer_isinstance_type_compare(node: ast.If | ast.IfExp) -> Error | None:
+    if (
+        isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Call)
+        and isinstance(node.test.left.func, ast.Name)
+        and node.test.left.func.id == "type"
+    ):
+        return PIE789(lineno=node.test.lineno, col_offset=node.test.col_offset)
+    return None
 
 
 PIE789 = partial(
-    ErrorLoc,
+    Error,
     message="PIE789: prefer-isinstance-type-compare: Use isinstance for comparing types.",
-    type=Flake8PieCheck789,
 )

--- a/flake8_pie/pie790_no_unnecessary_pass.py
+++ b/flake8_pie/pie790_no_unnecessary_pass.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-def get_unnecessary_pass_error(node: ast.ClassDef | ast.FunctionDef) -> ErrorLoc | None:
+def is_no_unnecessary_pass(node: ast.ClassDef | ast.FunctionDef) -> Error | None:
     if (
         len(node.body) > 1
         and isinstance(node.body[0], ast.Expr)
@@ -18,28 +18,4 @@ def get_unnecessary_pass_error(node: ast.ClassDef | ast.FunctionDef) -> ErrorLoc
     return None
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        error = get_unnecessary_pass_error(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        error = get_unnecessary_pass_error(node)
-        if error:
-            self.errors.append(error)
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck790(Flake8PieCheck):
-    visitor = Visitor
-
-
-PIE790 = partial(
-    ErrorLoc,
-    message="PIE790: no-unnecessary-pass: `pass` can be removed.",
-    type=Flake8PieCheck790,
-)
+PIE790 = partial(Error, message="PIE790: no-unnecessary-pass: `pass` can be removed.")

--- a/flake8_pie/pie791_no_pointless_statements.py
+++ b/flake8_pie/pie791_no_pointless_statements.py
@@ -3,23 +3,15 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_Expr(self, node: ast.Expr) -> None:
-        if isinstance(node.value, ast.Compare):
-            self.errors.append(PIE791(lineno=node.lineno, col_offset=node.col_offset))
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck791(Flake8PieCheck):
-    visitor = Visitor
+def is_no_pointless_statements(node: ast.Expr) -> Error | None:
+    if isinstance(node.value, ast.Compare):
+        return PIE791(lineno=node.lineno, col_offset=node.col_offset)
+    return None
 
 
 PIE791 = partial(
-    ErrorLoc,
-    message="PIE791: no-pointless-statements: Statement looks unnecessary.",
-    type=Flake8PieCheck791,
+    Error, message="PIE791: no-pointless-statements: Statement looks unnecessary."
 )

--- a/flake8_pie/pie792_no_inherit_object.py
+++ b/flake8_pie/pie792_no_inherit_object.py
@@ -3,26 +3,17 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        for base in node.bases:
-            if isinstance(base, ast.Name) and base.id == "object":
-                self.errors.append(
-                    PIE792(lineno=base.lineno, col_offset=base.col_offset)
-                )
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck792(Flake8PieCheck):
-    visitor = Visitor
+def is_no_inherit_object(node: ast.ClassDef) -> Error | None:
+    for base in node.bases:
+        if isinstance(base, ast.Name) and base.id == "object":
+            return PIE792(lineno=base.lineno, col_offset=base.col_offset)
+    return None
 
 
 PIE792 = partial(
-    ErrorLoc,
+    Error,
     message="PIE792: no-inherit-object: Inheriting from object is unnecssary in python3.",
-    type=Flake8PieCheck792,
 )

--- a/flake8_pie/pie793_prefer_dataclass.py
+++ b/flake8_pie/pie793_prefer_dataclass.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
 def _is_suspicious_assignment_stmt(stmt: ast.stmt) -> bool:
@@ -14,37 +14,22 @@ def _is_suspicious_assignment_stmt(stmt: ast.stmt) -> bool:
     )
 
 
-class Visitor(Flake8PieVisitor):
-    def __init__(self, filename: str) -> None:
-        super().__init__(filename)
-        self.inside_inheriting_cls_stack: list[bool] = []
-
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        inside_inheriting_cls = (
-            self.inside_inheriting_cls_stack and self.inside_inheriting_cls_stack[-1]
-        )
-        if (
-            not inside_inheriting_cls
-            and not node.bases
-            and not node.decorator_list
-            and any(_is_suspicious_assignment_stmt(stmt) for stmt in node.body)
-        ):
-            self.errors.append(PIE793(lineno=node.lineno, col_offset=node.col_offset))
-
-        is_inheriting_cls = len(node.bases) > 0
-        self.inside_inheriting_cls_stack.append(is_inheriting_cls)
-
-        self.generic_visit(node)
-
-        self.inside_inheriting_cls_stack.pop()
-
-
-class Flake8PieCheck793(Flake8PieCheck):
-    visitor = Visitor
+def is_prefer_dataclass(
+    node: ast.ClassDef, inside_inheriting_cls_stack: list[bool]
+) -> Error | None:
+    inside_inheriting_cls = (
+        inside_inheriting_cls_stack and inside_inheriting_cls_stack[-1]
+    )
+    if (
+        not inside_inheriting_cls
+        and not node.bases
+        and not node.decorator_list
+        and any(_is_suspicious_assignment_stmt(stmt) for stmt in node.body)
+    ):
+        return PIE793(lineno=node.lineno, col_offset=node.col_offset)
+    return None
 
 
 PIE793 = partial(
-    ErrorLoc,
-    message="PIE793: prefer-dataclass: Consider using a @dataclass.",
-    type=Flake8PieCheck793,
+    Error, message="PIE793: prefer-dataclass: Consider using a @dataclass."
 )

--- a/flake8_pie/pie794_dupe_class_field_definitions.py
+++ b/flake8_pie/pie794_dupe_class_field_definitions.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-def get_target_node(stmt: ast.stmt) -> ast.Name | None:
+def _get_target_node(stmt: ast.stmt) -> ast.Name | None:
     if isinstance(stmt, ast.Assign):
         if len(stmt.targets) == 1:
             target = stmt.targets[0]
@@ -18,32 +18,23 @@ def get_target_node(stmt: ast.stmt) -> ast.Name | None:
     return None
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        seen_targets: set[str] = set()
-        if node.bases and node.body:
-            for stmt in node.body:
-                target_node = get_target_node(stmt)
-                if target_node is None:
-                    continue
-                if target_node.id in seen_targets:
-                    self.errors.append(
-                        PIE794(
-                            lineno=target_node.lineno, col_offset=target_node.col_offset
-                        )
-                    )
-                else:
-                    seen_targets.add(target_node.id)
-
-        self.generic_visit(node)
-
-
-class Flake8PieCheck794(Flake8PieCheck):
-    visitor = Visitor
+def is_dupe_class_field_definition(node: ast.ClassDef) -> list[Error]:
+    seen_targets: set[str] = set()
+    errors: list[Error] = []
+    if node.bases and node.body:
+        for stmt in node.body:
+            target_node = _get_target_node(stmt)
+            if target_node is None:
+                continue
+            if target_node.id in seen_targets:
+                errors.append(
+                    PIE794(lineno=target_node.lineno, col_offset=target_node.col_offset)
+                )
+            else:
+                seen_targets.add(target_node.id)
+    return errors
 
 
 PIE794 = partial(
-    ErrorLoc,
-    message="PIE794: no-dupe-class-field-defs: This field is duplicated.",
-    type=Flake8PieCheck794,
+    Error, message="PIE794: no-dupe-class-field-defs: This field is duplicated."
 )

--- a/flake8_pie/pie795_prefer_stdlib_enums.py
+++ b/flake8_pie/pie795_prefer_stdlib_enums.py
@@ -3,57 +3,30 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
-def get_target_node(stmt: ast.stmt) -> ast.Name | None:
-    if isinstance(stmt, ast.Assign):
-        if len(stmt.targets) == 1:
-            target = stmt.targets[0]
-            if isinstance(target, ast.Name):
-                return target
-    elif isinstance(stmt, ast.AnnAssign):
-        if isinstance(stmt.target, ast.Name):
-            return stmt.target
+def is_prefer_stdlib_enums(
+    node: ast.ClassDef, inside_inheriting_cls_stack: list[bool]
+) -> Error | None:
+    inside_inheriting_cls = (
+        inside_inheriting_cls_stack and inside_inheriting_cls_stack[-1]
+    )
+    if (
+        not inside_inheriting_cls
+        and not node.bases
+        and not node.decorator_list
+        and len(node.body) > 1
+        and all(
+            isinstance(stmt, ast.Assign) and isinstance(stmt.value, (ast.Num, ast.Str))
+            for stmt in node.body
+        )
+    ):
+        return PIE795(lineno=node.lineno, col_offset=node.col_offset)
     return None
 
 
-class Visitor(Flake8PieVisitor):
-    def __init__(self, filename: str) -> None:
-        super().__init__(filename)
-        self.inside_inheriting_cls_stack: list[bool] = []
-
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        inside_inheriting_cls = (
-            self.inside_inheriting_cls_stack and self.inside_inheriting_cls_stack[-1]
-        )
-        if (
-            not inside_inheriting_cls
-            and not node.bases
-            and not node.decorator_list
-            and len(node.body) > 1
-            and all(
-                isinstance(stmt, ast.Assign)
-                and isinstance(stmt.value, (ast.Num, ast.Str))
-                for stmt in node.body
-            )
-        ):
-            self.errors.append(PIE795(lineno=node.lineno, col_offset=node.col_offset))
-
-        is_inheriting_cls = len(node.bases) > 0
-        self.inside_inheriting_cls_stack.append(is_inheriting_cls)
-
-        self.generic_visit(node)
-
-        self.inside_inheriting_cls_stack.pop()
-
-
-class Flake8PieCheck795(Flake8PieCheck):
-    visitor = Visitor
-
-
 PIE795 = partial(
-    ErrorLoc,
+    Error,
     message="PIE795: prefer-stdlib-enum: Considering using the builtin enum type.",
-    type=Flake8PieCheck795,
 )

--- a/flake8_pie/pie796_prefer_unique_enums.py
+++ b/flake8_pie/pie796_prefer_unique_enums.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
 def _extends_enum(node: ast.ClassDef) -> bool:
@@ -20,19 +20,13 @@ def _extends_enum(node: ast.ClassDef) -> bool:
     return False
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        if _extends_enum(node) and not node.decorator_list:
-            self.errors.append(PIE796(lineno=node.lineno, col_offset=node.col_offset))
-        self.generic_visit(node)
-
-
-class Flake8PieCheck796(Flake8PieCheck):
-    visitor = Visitor
+def is_prefer_unique_enum(node: ast.ClassDef) -> Error | None:
+    if _extends_enum(node) and not node.decorator_list:
+        return PIE796(lineno=node.lineno, col_offset=node.col_offset)
+    return None
 
 
 PIE796 = partial(
-    ErrorLoc,
+    Error,
     message="PIE796: prefer-unique-enums: Consider using the @enum.unique decorator.",
-    type=Flake8PieCheck796,
 )

--- a/flake8_pie/pie797_no_unnecessary_if_expr.py
+++ b/flake8_pie/pie797_no_unnecessary_if_expr.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import ErrorLoc, Flake8PieCheck, Flake8PieVisitor
+from flake8_pie.base import Error
 
 
 def _is_bool_literal(stmt: ast.expr) -> bool:
@@ -12,19 +12,13 @@ def _is_bool_literal(stmt: ast.expr) -> bool:
     )
 
 
-class Visitor(Flake8PieVisitor):
-    def visit_IfExp(self, node: ast.IfExp) -> None:
-        if _is_bool_literal(node.body) and _is_bool_literal(node.orelse):
-            self.errors.append(PIE797(lineno=node.lineno, col_offset=node.col_offset))
-        self.generic_visit(node)
-
-
-class Flake8PieCheck797(Flake8PieCheck):
-    visitor = Visitor
+def is_no_unnecessary_if_expr(node: ast.IfExp) -> Error | None:
+    if _is_bool_literal(node.body) and _is_bool_literal(node.orelse):
+        return PIE797(lineno=node.lineno, col_offset=node.col_offset)
+    return None
 
 
 PIE797 = partial(
-    ErrorLoc,
+    Error,
     message="PIE797: no-unnecessary-if-expr: Consider using bool() instead of an if expression.",
-    type=Flake8PieCheck797,
 )

--- a/flake8_pie/tests/test_pie781_assign_and_return.py
+++ b/flake8_pie/tests/test_pie781_assign_and_return.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck781
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie781_assign_and_return import PIE781, is_assign_and_return
-from flake8_pie.tests.utils import ErrorLoc
+from flake8_pie.tests.utils import to_errors
 
 func_test_cases = [
     (
@@ -90,9 +91,7 @@ def get_foo(id) -> Optional[Foo]:
 
 
 @pytest.mark.parametrize("func,expected,reason", func_test_cases)
-def test_is_assign_and_return(
-    func: str, expected: ErrorLoc | None, reason: str
-) -> None:
+def test_is_assign_and_return(func: str, expected: Error | None, reason: str) -> None:
 
     node = ast.parse(func)
 
@@ -105,5 +104,5 @@ def test_is_assign_and_return(
     expected_errors = [expected] if expected is not None else []
 
     assert (
-        list(Flake8PieCheck781(node, filename="foo.py").run()) == expected_errors
-    ), reason
+        to_errors(Flake8PieCheck(node, filename="foo.py").run())
+    ) == expected_errors, reason

--- a/flake8_pie/tests/test_pie783_celery_explicit_names.py
+++ b/flake8_pie/tests/test_pie783_celery_explicit_names.py
@@ -4,9 +4,9 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck783
+from flake8_pie import Flake8PieCheck
 from flake8_pie.pie783_celery_explicit_names import PIE783
-from flake8_pie.tests.utils import ErrorLoc
+from flake8_pie.tests.utils import Error, to_errors
 
 
 @pytest.mark.parametrize(
@@ -101,10 +101,10 @@ def bar():
         ),
     ],
 )
-def test_celery_task_name_lint(code: str, expected: ErrorLoc | None) -> None:
+def test_celery_task_name_lint(code: str, expected: Error | None) -> None:
     node = ast.parse(code)
     assert isinstance(node, ast.Module)
     expected_errors = [expected] if expected else []
     assert (
-        list(Flake8PieCheck783(node, filename="foo.py").run()) == expected_errors
+        to_errors(Flake8PieCheck(node, filename="foo.py").run()) == expected_errors
     ), "missing name property"

--- a/flake8_pie/tests/test_pie784_celery_crontab_args.py
+++ b/flake8_pie/tests/test_pie784_celery_crontab_args.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck784
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie784_celery_crontab_args import PIE784, _is_invalid_celery_crontab
-from flake8_pie.tests.utils import ErrorLoc
+from flake8_pie.tests.utils import to_errors
 
 
 @pytest.mark.parametrize(
@@ -62,7 +63,7 @@ crontab(minute="*/5")
         ),
     ],
 )
-def test_celery_crontab_named_args(code: str, expected: ErrorLoc | None) -> None:
+def test_celery_crontab_named_args(code: str, expected: Error | None) -> None:
     """
     ensure we pass a explicit params to celery's crontab
     see: https://github.com/celery/celery/blob/0736cff9d908c0519e07babe4de9c399c87cb32b/celery/schedules.py#L403
@@ -77,8 +78,8 @@ def test_celery_crontab_named_args(code: str, expected: ErrorLoc | None) -> None
     assert isinstance(node, ast.Module)
     expected_errors = [expected] if expected else []
     assert (
-        list(Flake8PieCheck784(node, filename="foo.py").run()) == expected_errors
-    ), "missing a required argument"
+        to_errors(Flake8PieCheck(node, filename="foo.py").run())
+    ) == expected_errors, "missing a required argument"
 
 
 @pytest.mark.parametrize(

--- a/flake8_pie/tests/test_pie785_celery_require_tasks_expire.py
+++ b/flake8_pie/tests/test_pie785_celery_require_tasks_expire.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck785
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie785_celery_require_tasks_expire import PIE785
-from flake8_pie.tests.utils import ErrorLoc
+from flake8_pie.tests.utils import to_errors
 
 # TODO(sbdchd):
 # add support for beat tasks configured via hook
@@ -69,10 +70,10 @@ foo.apply_async(
         ),
     ],
 )
-def test_celery_require_task_expiration(code: str, expected: ErrorLoc | None) -> None:
+def test_celery_require_task_expiration(code: str, expected: Error | None) -> None:
     node = ast.parse(code)
     assert isinstance(node, ast.Module)
     expected_errors = [expected] if expected else []
     assert (
-        list(Flake8PieCheck785(node, filename="foo.py").run()) == expected_errors
-    ), "missing expiration"
+        to_errors(Flake8PieCheck(node, filename="foo.py").run())
+    ) == expected_errors, "missing expiration"

--- a/flake8_pie/tests/test_pie786_precise_exception_handler.py
+++ b/flake8_pie/tests/test_pie786_precise_exception_handler.py
@@ -4,9 +4,9 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck786
-from flake8_pie.pie786_precise_exception_handler import PIE786, has_bad_control_flow
-from flake8_pie.tests.utils import ErrorLoc
+from flake8_pie import Flake8PieCheck
+from flake8_pie.pie786_precise_exception_handler import PIE786, _has_bad_control_flow
+from flake8_pie.tests.utils import Error, to_errors
 
 
 @pytest.mark.parametrize(
@@ -196,12 +196,12 @@ for x in my_results:
         ),
     ],
 )
-def test_broad_except(try_statement: str, error: ErrorLoc | None) -> None:
+def test_broad_except(try_statement: str, error: Error | None) -> None:
     expr = ast.parse(try_statement)
     if error is None:
-        assert list(Flake8PieCheck786(expr, filename="foo.py").run()) == []
+        assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == []
     else:
-        assert list(Flake8PieCheck786(expr, filename="foo.py").run()) == [error]
+        assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == [error]
 
 
 EXPRESSIONS = [
@@ -227,4 +227,4 @@ raise
 def test_has_bad_control_flow() -> None:
     for expression in EXPRESSIONS:
         expr = ast.parse(expression)
-        assert has_bad_control_flow(expr.body) is True
+        assert _has_bad_control_flow(expr.body) is True

--- a/flake8_pie/tests/test_pie787_no_len_condition.py
+++ b/flake8_pie/tests/test_pie787_no_len_condition.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck787
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie787_no_len_condition import PIE787
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 
 @pytest.mark.parametrize(
@@ -62,6 +63,6 @@ if not foo: ...
         ),
     ],
 )
-def test_no_len_condition(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_len_condition(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck787(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie788_no_bool_condition.py
+++ b/flake8_pie/tests/test_pie788_no_bool_condition.py
@@ -4,9 +4,9 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck788
+from flake8_pie import Flake8PieCheck
 from flake8_pie.pie788_no_bool_condition import PIE788
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import Error, ex, to_errors
 
 
 @pytest.mark.parametrize(
@@ -62,6 +62,6 @@ if not foo: ...
         ),
     ],
 )
-def test_no_bool_condition(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_bool_condition(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck788(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie789_prefer_isinstance_type_compare.py
+++ b/flake8_pie/tests/test_pie789_prefer_isinstance_type_compare.py
@@ -4,9 +4,9 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck789
+from flake8_pie import Flake8PieCheck
 from flake8_pie.pie789_prefer_isinstance_type_compare import PIE789
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import Error, ex, to_errors
 
 
 @pytest.mark.parametrize(
@@ -35,6 +35,12 @@ if type(foo) is not dict: ...
 if type(foo) == Bar: ...
 """,
             errors=[PIE789(lineno=2, col_offset=3)],
+        ),
+        ex(
+            code="""
+foo = "bar" if type(foo) == Bar else "buzz"
+""",
+            errors=[PIE789(lineno=2, col_offset=15)],
         ),
         ex(
             code="""
@@ -68,6 +74,6 @@ if not isinstance(foo, Bar): ...
         ),
     ],
 )
-def test_prefer_isinstance_type_compare(code: str, errors: list[ErrorLoc]) -> None:
+def test_prefer_isinstance_type_compare(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck789(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie790_no_unnecessary_pass.py
+++ b/flake8_pie/tests/test_pie790_no_unnecessary_pass.py
@@ -4,9 +4,9 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck790
+from flake8_pie import Flake8PieCheck
 from flake8_pie.pie790_no_unnecessary_pass import PIE790
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import Error, ex, to_errors
 
 
 @pytest.mark.parametrize(
@@ -72,6 +72,6 @@ def foo() -> None:
         ),
     ],
 )
-def test_no_unnecessary_pass(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_unnecessary_pass(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck790(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie791_no_pointless_statements.py
+++ b/flake8_pie/tests/test_pie791_no_pointless_statements.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck791
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie791_no_pointless_statements import PIE791
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 
 @pytest.mark.parametrize(
@@ -70,6 +71,6 @@ process(data == "foo")
         ),
     ],
 )
-def test_no_pointless_statements(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_pointless_statements(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck791(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie792_no_inherit_object.py
+++ b/flake8_pie/tests/test_pie792_no_inherit_object.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck792
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie792_no_inherit_object import PIE792
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 
 @pytest.mark.parametrize(
@@ -52,6 +53,6 @@ class Foo:
         ),
     ],
 )
-def test_no_inherit_object(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_inherit_object(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck792(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie793_prefer_dataclass.py
+++ b/flake8_pie/tests/test_pie793_prefer_dataclass.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck793
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie793_prefer_dataclass import PIE793
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 PREFER_DATACLASS_EXAMPLES = [
     ex(
@@ -42,16 +43,16 @@ class Foo:
     ex(
         code="""
 class FakeEnum:
-    A = "A"
-    B = "B"
-    C = "C"
+    A: int = 1
+    B = 2
+    C = 3
 """,
-        errors=[],
+        errors=[PIE793(lineno=2, col_offset=0)],
     ),
     ex(
         code="""
 @enum.unique
-class FakeEnum(enum.Enum):
+class FooEnum(enum.Enum):
     A = "A"
     B = "B"
     C = "C"
@@ -155,6 +156,6 @@ class BulkSerializerTaskMixin:
 
 
 @pytest.mark.parametrize("code,errors", PREFER_DATACLASS_EXAMPLES)
-def test_prefer_dataclass(code: str, errors: list[ErrorLoc]) -> None:
+def test_prefer_dataclass(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck793(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie794_dupe_class_field_definitions.py
+++ b/flake8_pie/tests/test_pie794_dupe_class_field_definitions.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck794
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie794_dupe_class_field_definitions import PIE794
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 NO_DUPE_FIELD_EXAMPLES = [
     ex(
@@ -53,6 +54,6 @@ class User(BaseModel):
 
 
 @pytest.mark.parametrize("code,errors", NO_DUPE_FIELD_EXAMPLES)
-def test_no_dupe_class_fields(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_dupe_class_fields(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck794(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie795_prefer_stdlib_enums.py
+++ b/flake8_pie/tests/test_pie795_prefer_stdlib_enums.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck795
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie795_prefer_stdlib_enums import PIE795
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 PREFER_STDLIB_ENUM_EXAMPLES = [
     ex(
@@ -26,15 +27,6 @@ class FakeEnum:
     C = 3
 """,
         errors=[PIE795(lineno=2, col_offset=0)],
-    ),
-    ex(
-        code="""
-class FakeEnum:
-    A: int = 1
-    B = 2
-    C = 3
-""",
-        errors=[],
     ),
     ex(
         code="""
@@ -96,6 +88,6 @@ class Foo(Bar):
 
 
 @pytest.mark.parametrize("code,errors", PREFER_STDLIB_ENUM_EXAMPLES)
-def test_prefer_stdlib_enum(code: str, errors: list[ErrorLoc]) -> None:
+def test_prefer_stdlib_enum(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck795(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie796_prefer_unique_enums.py
+++ b/flake8_pie/tests/test_pie796_prefer_unique_enums.py
@@ -4,9 +4,10 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck796
+from flake8_pie import Flake8PieCheck
+from flake8_pie.base import Error
 from flake8_pie.pie796_prefer_unique_enums import PIE796
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import ex, to_errors
 
 PREFER_UNIQUE_ENUM_EXAMPLES = [
     ex(
@@ -80,6 +81,6 @@ class FakeEnum(enum.Enum):
 
 
 @pytest.mark.parametrize("code,errors", PREFER_UNIQUE_ENUM_EXAMPLES)
-def test_prefer_unique_enums(code: str, errors: list[ErrorLoc]) -> None:
+def test_prefer_unique_enums(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck796(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie797_no_unnecessary_if_expr.py
+++ b/flake8_pie/tests/test_pie797_no_unnecessary_if_expr.py
@@ -4,9 +4,9 @@ import ast
 
 import pytest
 
-from flake8_pie import Flake8PieCheck797
+from flake8_pie import Flake8PieCheck
 from flake8_pie.pie797_no_unnecessary_if_expr import PIE797
-from flake8_pie.tests.utils import ErrorLoc, ex
+from flake8_pie.tests.utils import Error, ex, to_errors
 
 NO_UNNECSSARY_IF_EXPR = [
     ex(
@@ -43,6 +43,6 @@ bar(is_valid=bool(buzz()))
 
 
 @pytest.mark.parametrize("code,errors", NO_UNNECSSARY_IF_EXPR)
-def test_no_unnecessary_if_expr(code: str, errors: list[ErrorLoc]) -> None:
+def test_no_unnecessary_if_expr(code: str, errors: list[Error]) -> None:
     expr = ast.parse(code)
-    assert list(Flake8PieCheck797(expr, filename="foo.py").run()) == errors
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/utils.py
+++ b/flake8_pie/tests/utils.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Iterable, NamedTuple
 
-from flake8_pie.base import ErrorLoc
+from flake8_pie.base import Error, Flake8Error
 
 
 class ex(NamedTuple):
     code: str
-    errors: list[ErrorLoc]
+    errors: list[Error]
+
+
+def to_errors(flake8_err: Iterable[Flake8Error]) -> list[Error]:
+    return [
+        Error(lineno=err.lineno, col_offset=err.col_offset, message=err.message)
+        for err in flake8_err
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,22 +34,7 @@ isort = "^4.3"
 
 [tool.poetry.plugins]
 [tool.poetry.plugins."flake8.extension"]
-PIE781 = "flake8_pie:Flake8PieCheck781"
-PIE783 = "flake8_pie:Flake8PieCheck783"
-PIE784 = "flake8_pie:Flake8PieCheck784"
-PIE785 = "flake8_pie:Flake8PieCheck785"
-PIE786 = "flake8_pie:Flake8PieCheck786"
-PIE787 = "flake8_pie:Flake8PieCheck787"
-PIE788 = "flake8_pie:Flake8PieCheck788"
-PIE789 = "flake8_pie:Flake8PieCheck789"
-PIE790 = "flake8_pie:Flake8PieCheck790"
-PIE791 = "flake8_pie:Flake8PieCheck791"
-PIE792 = "flake8_pie:Flake8PieCheck792"
-PIE793 = "flake8_pie:Flake8PieCheck793"
-PIE794 = "flake8_pie:Flake8PieCheck794"
-PIE795 = "flake8_pie:Flake8PieCheck795"
-PIE796 = "flake8_pie:Flake8PieCheck796"
-PIE797 = "flake8_pie:Flake8PieCheck797"
+PIE = "flake8_pie:Flake8PieCheck"
 
 [build-system]
 requires = ["poetry>=0.12", "setuptools"]


### PR DESCRIPTION
By using a checker for each rule we were iterating over the AST each time.
So for 10 rules we'd iterate over the same module 10 times, not great.

Instead we combine the logic into one visitor. There's probably a better
way to abstract this, but for now this matches the behavior and offers
better perf.