### PR TITLE
ref: visitor error collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ Note: flake8-pie requires Python 3.6 or greater
 
 ## lints
 
-- PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.
-- PIE783: Celery tasks should have explicit names.
-- PIE784: Celery crontab is missing explicit arguments.
-- PIE785: Celery tasks should have expirations.
-
 ### PIE781: assign-and-return
 
 Based on Clippy's

--- a/flake8_pie/__init__.py
+++ b/flake8_pie/__init__.py
@@ -4,26 +4,28 @@ import ast
 from typing import Iterable
 
 from flake8_pie.base import Error, Flake8Error
-from flake8_pie.pie781_assign_and_return import is_assign_and_return
-from flake8_pie.pie783_celery_explicit_names import is_celery_explicit_names
-from flake8_pie.pie784_celery_crontab_args import is_celery_crontab_args
-from flake8_pie.pie785_celery_require_tasks_expire import is_celery_require_tasks_expire
-from flake8_pie.pie786_precise_exception_handler import is_precise_exception_handler
-from flake8_pie.pie787_no_len_condition import is_no_len_condition
-from flake8_pie.pie788_no_bool_condition import is_no_bool_condition
+from flake8_pie.pie781_assign_and_return import pie781_assign_and_return
+from flake8_pie.pie783_celery_explicit_names import pie783_celery_explicit_names
+from flake8_pie.pie784_celery_crontab_args import pie784_celery_crontab_args
+from flake8_pie.pie785_celery_require_tasks_expire import (
+    pie785_celery_require_tasks_expire,
+)
+from flake8_pie.pie786_precise_exception_handler import pie786_precise_exception_handler
+from flake8_pie.pie787_no_len_condition import pie787_no_len_condition
+from flake8_pie.pie788_no_bool_condition import pie788_no_bool_condition
 from flake8_pie.pie789_prefer_isinstance_type_compare import (
-    is_prefer_isinstance_type_compare,
+    pie789_prefer_isinstance_type_compare,
 )
-from flake8_pie.pie790_no_unnecessary_pass import is_no_unnecessary_pass
-from flake8_pie.pie791_no_pointless_statements import is_no_pointless_statements
-from flake8_pie.pie792_no_inherit_object import is_no_inherit_object
-from flake8_pie.pie793_prefer_dataclass import is_prefer_dataclass
+from flake8_pie.pie790_no_unnecessary_pass import pie790_no_unnecessary_pass
+from flake8_pie.pie791_no_pointless_statements import pie791_no_pointless_statements
+from flake8_pie.pie792_no_inherit_object import pie792_no_inherit_object
+from flake8_pie.pie793_prefer_dataclass import pie793_prefer_dataclass
 from flake8_pie.pie794_dupe_class_field_definitions import (
-    is_dupe_class_field_definition,
+    pie794_dupe_class_field_definition,
 )
-from flake8_pie.pie795_prefer_stdlib_enums import is_prefer_stdlib_enums
-from flake8_pie.pie796_prefer_unique_enums import is_prefer_unique_enum
-from flake8_pie.pie797_no_unnecessary_if_expr import is_no_unnecessary_if_expr
+from flake8_pie.pie795_prefer_stdlib_enums import pie795_prefer_stdlib_enums
+from flake8_pie.pie796_prefer_unique_enums import pie786_prefer_unique_enum
+from flake8_pie.pie797_no_unnecessary_if_expr import pie797_no_unnecessary_if_expr
 
 
 class Flake8PieVisitor(ast.NodeVisitor):
@@ -33,45 +35,19 @@ class Flake8PieVisitor(ast.NodeVisitor):
         self.inside_inheriting_cls_stack: list[bool] = []
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        # TODO(sbdchd): rename all these functions to `check_$number_$name` and
-        # have them return a list or maybe take in the list and mutate it
-        error = is_assign_and_return(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_celery_explicit_names(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_no_unnecessary_pass(node)
-        if error:
-            self.errors.append(error)
+        pie781_assign_and_return(node, self.errors)
+        pie783_celery_explicit_names(node, self.errors)
+        pie790_no_unnecessary_pass(node, self.errors)
 
         self.generic_visit(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-
-        error = is_no_unnecessary_pass(node)
-        if error:
-            self.errors.append(error)
-
-        self.errors += is_dupe_class_field_definition(node)
-
-        error = is_no_inherit_object(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_prefer_dataclass(node, self.inside_inheriting_cls_stack)
-        if error:
-            self.errors.append(error)
-
-        error = is_prefer_stdlib_enums(node, self.inside_inheriting_cls_stack)
-        if error:
-            self.errors.append(error)
-
-        error = is_prefer_unique_enum(node)
-        if error:
-            self.errors.append(error)
+        pie790_no_unnecessary_pass(node, self.errors)
+        pie794_dupe_class_field_definition(node, self.errors)
+        pie792_no_inherit_object(node, self.errors)
+        pie793_prefer_dataclass(node, self.errors, self.inside_inheriting_cls_stack)
+        pie795_prefer_stdlib_enums(node, self.errors, self.inside_inheriting_cls_stack)
+        pie786_prefer_unique_enum(node, self.errors)
 
         is_inheriting_cls = len(node.bases) > 0
         self.inside_inheriting_cls_stack.append(is_inheriting_cls)
@@ -79,67 +55,38 @@ class Flake8PieVisitor(ast.NodeVisitor):
         self.inside_inheriting_cls_stack.pop()
 
     def visit_Call(self, node: ast.Call) -> None:
-        error = is_celery_crontab_args(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_celery_require_tasks_expire(node)
-        if error:
-            self.errors.append(error)
+        pie784_celery_crontab_args(node, self.errors)
+        pie785_celery_require_tasks_expire(node, self.errors)
 
         self.generic_visit(node)
 
     def visit_Dict(self, node: ast.Dict) -> None:
-        error = is_celery_require_tasks_expire(node)
-        if error:
-            self.errors.append(error)
+        pie785_celery_require_tasks_expire(node, self.errors)
 
         self.generic_visit(node)
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
-        error = is_precise_exception_handler(node)
-        if error:
-            self.errors.append(error)
+        pie786_precise_exception_handler(node, self.errors)
 
         self.generic_visit(node)
 
     def visit_Expr(self, node: ast.Expr) -> None:
-        error = is_no_pointless_statements(node)
-        if error:
-            self.errors.append(error)
+        pie791_no_pointless_statements(node, self.errors)
+
         self.generic_visit(node)
 
     def visit_If(self, node: ast.If) -> None:
-        error = is_no_len_condition(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_prefer_isinstance_type_compare(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_no_bool_condition(node)
-        if error:
-            self.errors.append(error)
+        pie787_no_len_condition(node, self.errors)
+        pie789_prefer_isinstance_type_compare(node, self.errors)
+        pie788_no_bool_condition(node, self.errors)
 
         self.generic_visit(node)
 
     def visit_IfExp(self, node: ast.IfExp) -> None:
-        error = is_no_len_condition(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_no_bool_condition(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_prefer_isinstance_type_compare(node)
-        if error:
-            self.errors.append(error)
-
-        error = is_no_unnecessary_if_expr(node)
-        if error:
-            self.errors.append(error)
+        pie787_no_len_condition(node, self.errors)
+        pie788_no_bool_condition(node, self.errors)
+        pie789_prefer_isinstance_type_compare(node, self.errors)
+        pie797_no_unnecessary_if_expr(node, self.errors)
 
         self.generic_visit(node)
 

--- a/flake8_pie/pie781_assign_and_return.py
+++ b/flake8_pie/pie781_assign_and_return.py
@@ -25,7 +25,7 @@ def _get_assign_target_id(stmt: ast.stmt) -> str | None:
     return None
 
 
-def is_assign_and_return(func: ast.FunctionDef) -> Error | None:
+def pie781_assign_and_return(func: ast.FunctionDef, errors: list[Error]) -> None:
     """
     check a FunctionDef for assignment and return where a user assigns to a
     variable and returns that variable instead of just returning
@@ -39,11 +39,9 @@ def is_assign_and_return(func: ast.FunctionDef) -> Error | None:
             assign_stmt = func.body[-2]
             assign_id = _get_assign_target_id(assign_stmt)
             if return_stmt.value.id == assign_id:
-                return PIE781(
-                    lineno=return_stmt.lineno, col_offset=return_stmt.col_offset
+                errors.append(
+                    PIE781(lineno=return_stmt.lineno, col_offset=return_stmt.col_offset)
                 )
-
-    return None
 
 
 PIE781 = partial(

--- a/flake8_pie/pie783_celery_explicit_names.py
+++ b/flake8_pie/pie783_celery_explicit_names.py
@@ -14,7 +14,7 @@ CELERY_SHARED_TASK_NAME = "shared_task"
 CELERY_TASK_NAME = "task"
 
 
-def is_celery_explicit_names(func: ast.FunctionDef) -> Error | None:
+def pie783_celery_explicit_names(func: ast.FunctionDef, errors: list[Error]) -> None:
     """
     check if a Celery task definition is missing an explicit name.
     """
@@ -25,23 +25,22 @@ def is_celery_explicit_names(func: ast.FunctionDef) -> Error | None:
                 and isinstance(dec.value, ast.Name)
                 and dec.attr == CELERY_TASK_NAME
             ):
-                return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
+                errors.append(PIE783(lineno=dec.lineno, col_offset=dec.col_offset))
             if isinstance(dec, ast.Name) and dec.id == CELERY_SHARED_TASK_NAME:
-                return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
+                errors.append(PIE783(lineno=dec.lineno, col_offset=dec.col_offset))
             if isinstance(dec, ast.Call):
                 if (
                     isinstance(dec.func, ast.Name)
                     and dec.func.id == CELERY_SHARED_TASK_NAME
                     and not has_name_kwarg(dec)
                 ):
-                    return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
+                    errors.append(PIE783(lineno=dec.lineno, col_offset=dec.col_offset))
                 if (
                     isinstance(dec.func, ast.Attribute)
                     and dec.func.attr == CELERY_TASK_NAME
                     and not has_name_kwarg(dec)
                 ):
-                    return PIE783(lineno=dec.lineno, col_offset=dec.col_offset)
-    return None
+                    errors.append(PIE783(lineno=dec.lineno, col_offset=dec.col_offset))
 
 
 PIE783 = partial(Error, message="PIE783: Celery tasks should have explicit names.")

--- a/flake8_pie/pie784_celery_crontab_args.py
+++ b/flake8_pie/pie784_celery_crontab_args.py
@@ -27,19 +27,19 @@ def _is_invalid_celery_crontab(*, kwargs: list[ast.keyword]) -> bool:
     return False
 
 
-def is_celery_crontab_args(call: ast.Call) -> Error | None:
+def pie784_celery_crontab_args(call: ast.Call, errors: list[Error]) -> None:
     """
     require that a user pass all time increments that are smaller than the
     highest one they specify.
 
     e.g., user passes day_of_week, then they must pass hour and minute
     """
-    if isinstance(call.func, ast.Name):
-        if call.func.id == "crontab":
-            if _is_invalid_celery_crontab(kwargs=call.keywords):
-                return PIE784(lineno=call.lineno, col_offset=call.col_offset)
-
-    return None
+    if (
+        isinstance(call.func, ast.Name)
+        and call.func.id == "crontab"
+        and _is_invalid_celery_crontab(kwargs=call.keywords)
+    ):
+        errors.append(PIE784(lineno=call.lineno, col_offset=call.col_offset))
 
 
 PIE784 = partial(Error, message="PIE784: Celery crontab is missing explicit arguments.")

--- a/flake8_pie/pie786_precise_exception_handler.py
+++ b/flake8_pie/pie786_precise_exception_handler.py
@@ -40,7 +40,9 @@ def _body_has_raise(except_body: list[ast.stmt]) -> bool:
     return False
 
 
-def is_precise_exception_handler(node: ast.ExceptHandler) -> Error | None:
+def pie786_precise_exception_handler(
+    node: ast.ExceptHandler, errors: list[Error]
+) -> None:
     """
     ensure try...except is not called with Exception, BaseException, or no argument
     """
@@ -49,13 +51,12 @@ def is_precise_exception_handler(node: ast.ExceptHandler) -> Error | None:
     if isinstance(node.type, ast.Tuple):
         for elt in node.type.elts:
             if (isinstance(elt, ast.Name) or elt is None) and _is_bad_except_type(elt):
-                return PIE786(lineno=elt.lineno, col_offset=elt.col_offset)
-        return None
+                errors.append(PIE786(lineno=elt.lineno, col_offset=elt.col_offset))
+                return
     if (isinstance(node.type, ast.Name) or node.type is None) and _is_bad_except_type(
         node.type
     ):
-        return PIE786(lineno=node.lineno, col_offset=node.col_offset)
-    return None
+        errors.append(PIE786(lineno=node.lineno, col_offset=node.col_offset))
 
 
 PIE786 = partial(Error, message="PIE786: Use precise exception handlers.")

--- a/flake8_pie/pie787_no_len_condition.py
+++ b/flake8_pie/pie787_no_len_condition.py
@@ -7,10 +7,9 @@ from flake8_pie.base import Error
 from flake8_pie.utils import is_if_test_func_call
 
 
-def is_no_len_condition(node: ast.If | ast.IfExp) -> Error | None:
+def pie787_no_len_condition(node: ast.If | ast.IfExp, errors: list[Error]) -> None:
     if is_if_test_func_call(node=node, func_name="len"):
-        return PIE787(lineno=node.test.lineno, col_offset=node.test.col_offset)
-    return None
+        errors.append(PIE787(lineno=node.test.lineno, col_offset=node.test.col_offset))
 
 
 PIE787 = partial(

--- a/flake8_pie/pie788_no_bool_condition.py
+++ b/flake8_pie/pie788_no_bool_condition.py
@@ -7,10 +7,9 @@ from flake8_pie.base import Error
 from flake8_pie.utils import is_if_test_func_call
 
 
-def is_no_bool_condition(node: ast.If | ast.IfExp) -> Error | None:
+def pie788_no_bool_condition(node: ast.If | ast.IfExp, errors: list[Error]) -> None:
     if is_if_test_func_call(node=node, func_name="bool"):
-        return PIE788(lineno=node.test.lineno, col_offset=node.test.col_offset)
-    return None
+        errors.append(PIE788(lineno=node.test.lineno, col_offset=node.test.col_offset))
 
 
 PIE788 = partial(

--- a/flake8_pie/pie789_prefer_isinstance_type_compare.py
+++ b/flake8_pie/pie789_prefer_isinstance_type_compare.py
@@ -6,15 +6,16 @@ from functools import partial
 from flake8_pie.base import Error
 
 
-def is_prefer_isinstance_type_compare(node: ast.If | ast.IfExp) -> Error | None:
+def pie789_prefer_isinstance_type_compare(
+    node: ast.If | ast.IfExp, errors: list[Error]
+) -> None:
     if (
         isinstance(node.test, ast.Compare)
         and isinstance(node.test.left, ast.Call)
         and isinstance(node.test.left.func, ast.Name)
         and node.test.left.func.id == "type"
     ):
-        return PIE789(lineno=node.test.lineno, col_offset=node.test.col_offset)
-    return None
+        errors.append(PIE789(lineno=node.test.lineno, col_offset=node.test.col_offset))
 
 
 PIE789 = partial(

--- a/flake8_pie/pie790_no_unnecessary_pass.py
+++ b/flake8_pie/pie790_no_unnecessary_pass.py
@@ -6,16 +6,18 @@ from functools import partial
 from flake8_pie.base import Error
 
 
-def is_no_unnecessary_pass(node: ast.ClassDef | ast.FunctionDef) -> Error | None:
+def pie790_no_unnecessary_pass(
+    node: ast.ClassDef | ast.FunctionDef, errors: list[Error]
+) -> None:
     if (
         len(node.body) > 1
         and isinstance(node.body[0], ast.Expr)
         and isinstance(node.body[0].value, ast.Str)
         and isinstance(node.body[1], ast.Pass)
     ):
-        return PIE790(lineno=node.body[1].lineno, col_offset=node.body[1].col_offset)
-
-    return None
+        errors.append(
+            PIE790(lineno=node.body[1].lineno, col_offset=node.body[1].col_offset)
+        )
 
 
 PIE790 = partial(Error, message="PIE790: no-unnecessary-pass: `pass` can be removed.")

--- a/flake8_pie/pie791_no_pointless_statements.py
+++ b/flake8_pie/pie791_no_pointless_statements.py
@@ -6,10 +6,9 @@ from functools import partial
 from flake8_pie.base import Error
 
 
-def is_no_pointless_statements(node: ast.Expr) -> Error | None:
+def pie791_no_pointless_statements(node: ast.Expr, errors: list[Error]) -> None:
     if isinstance(node.value, ast.Compare):
-        return PIE791(lineno=node.lineno, col_offset=node.col_offset)
-    return None
+        errors.append(PIE791(lineno=node.lineno, col_offset=node.col_offset))
 
 
 PIE791 = partial(

--- a/flake8_pie/pie792_no_inherit_object.py
+++ b/flake8_pie/pie792_no_inherit_object.py
@@ -6,11 +6,10 @@ from functools import partial
 from flake8_pie.base import Error
 
 
-def is_no_inherit_object(node: ast.ClassDef) -> Error | None:
+def pie792_no_inherit_object(node: ast.ClassDef, errors: list[Error]) -> None:
     for base in node.bases:
         if isinstance(base, ast.Name) and base.id == "object":
-            return PIE792(lineno=base.lineno, col_offset=base.col_offset)
-    return None
+            errors.append(PIE792(lineno=base.lineno, col_offset=base.col_offset))
 
 
 PIE792 = partial(

--- a/flake8_pie/pie793_prefer_dataclass.py
+++ b/flake8_pie/pie793_prefer_dataclass.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from functools import partial
+from typing import Sequence
 
 from flake8_pie.base import Error
 
@@ -14,9 +15,9 @@ def _is_suspicious_assignment_stmt(stmt: ast.stmt) -> bool:
     )
 
 
-def is_prefer_dataclass(
-    node: ast.ClassDef, inside_inheriting_cls_stack: list[bool]
-) -> Error | None:
+def pie793_prefer_dataclass(
+    node: ast.ClassDef, errors: list[Error], inside_inheriting_cls_stack: Sequence[bool]
+) -> None:
     inside_inheriting_cls = (
         inside_inheriting_cls_stack and inside_inheriting_cls_stack[-1]
     )
@@ -26,8 +27,7 @@ def is_prefer_dataclass(
         and not node.decorator_list
         and any(_is_suspicious_assignment_stmt(stmt) for stmt in node.body)
     ):
-        return PIE793(lineno=node.lineno, col_offset=node.col_offset)
-    return None
+        errors.append(PIE793(lineno=node.lineno, col_offset=node.col_offset))
 
 
 PIE793 = partial(

--- a/flake8_pie/pie794_dupe_class_field_definitions.py
+++ b/flake8_pie/pie794_dupe_class_field_definitions.py
@@ -18,9 +18,8 @@ def _get_target_node(stmt: ast.stmt) -> ast.Name | None:
     return None
 
 
-def is_dupe_class_field_definition(node: ast.ClassDef) -> list[Error]:
+def pie794_dupe_class_field_definition(node: ast.ClassDef, errors: list[Error]) -> None:
     seen_targets: set[str] = set()
-    errors: list[Error] = []
     if node.bases and node.body:
         for stmt in node.body:
             target_node = _get_target_node(stmt)
@@ -32,7 +31,6 @@ def is_dupe_class_field_definition(node: ast.ClassDef) -> list[Error]:
                 )
             else:
                 seen_targets.add(target_node.id)
-    return errors
 
 
 PIE794 = partial(

--- a/flake8_pie/pie795_prefer_stdlib_enums.py
+++ b/flake8_pie/pie795_prefer_stdlib_enums.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import ast
 from functools import partial
+from typing import Sequence
 
 from flake8_pie.base import Error
 
 
-def is_prefer_stdlib_enums(
-    node: ast.ClassDef, inside_inheriting_cls_stack: list[bool]
-) -> Error | None:
+def pie795_prefer_stdlib_enums(
+    node: ast.ClassDef, errors: list[Error], inside_inheriting_cls_stack: Sequence[bool]
+) -> None:
     inside_inheriting_cls = (
         inside_inheriting_cls_stack and inside_inheriting_cls_stack[-1]
     )
@@ -22,8 +23,7 @@ def is_prefer_stdlib_enums(
             for stmt in node.body
         )
     ):
-        return PIE795(lineno=node.lineno, col_offset=node.col_offset)
-    return None
+        errors.append(PIE795(lineno=node.lineno, col_offset=node.col_offset))
 
 
 PIE795 = partial(

--- a/flake8_pie/pie796_prefer_unique_enums.py
+++ b/flake8_pie/pie796_prefer_unique_enums.py
@@ -20,10 +20,9 @@ def _extends_enum(node: ast.ClassDef) -> bool:
     return False
 
 
-def is_prefer_unique_enum(node: ast.ClassDef) -> Error | None:
+def pie786_prefer_unique_enum(node: ast.ClassDef, errors: list[Error]) -> None:
     if _extends_enum(node) and not node.decorator_list:
-        return PIE796(lineno=node.lineno, col_offset=node.col_offset)
-    return None
+        errors.append(PIE796(lineno=node.lineno, col_offset=node.col_offset))
 
 
 PIE796 = partial(

--- a/flake8_pie/pie797_no_unnecessary_if_expr.py
+++ b/flake8_pie/pie797_no_unnecessary_if_expr.py
@@ -12,10 +12,9 @@ def _is_bool_literal(stmt: ast.expr) -> bool:
     )
 
 
-def is_no_unnecessary_if_expr(node: ast.IfExp) -> Error | None:
+def pie797_no_unnecessary_if_expr(node: ast.IfExp, errors: list[Error]) -> None:
     if _is_bool_literal(node.body) and _is_bool_literal(node.orelse):
-        return PIE797(lineno=node.lineno, col_offset=node.col_offset)
-    return None
+        errors.append(PIE797(lineno=node.lineno, col_offset=node.col_offset))
 
 
 PIE797 = partial(

--- a/flake8_pie/tests/test_pie781_assign_and_return.py
+++ b/flake8_pie/tests/test_pie781_assign_and_return.py
@@ -6,7 +6,7 @@ import pytest
 
 from flake8_pie import Flake8PieCheck
 from flake8_pie.base import Error
-from flake8_pie.pie781_assign_and_return import PIE781, is_assign_and_return
+from flake8_pie.pie781_assign_and_return import PIE781
 from flake8_pie.tests.utils import to_errors
 
 func_test_cases = [
@@ -92,17 +92,7 @@ def get_foo(id) -> Optional[Foo]:
 
 @pytest.mark.parametrize("func,expected,reason", func_test_cases)
 def test_is_assign_and_return(func: str, expected: Error | None, reason: str) -> None:
-
-    node = ast.parse(func)
-
-    assert isinstance(node, ast.Module)
-
-    func_def = node.body[0]
-    assert isinstance(func_def, ast.FunctionDef)
-    assert is_assign_and_return(func_def) == expected, reason
-
     expected_errors = [expected] if expected is not None else []
-
     assert (
-        to_errors(Flake8PieCheck(node, filename="foo.py").run())
+        to_errors(Flake8PieCheck(ast.parse(func), filename="foo.py").run())
     ) == expected_errors, reason


### PR DESCRIPTION
Previous approach was a bit messy, opted for mutating the list directly
in the lint rules. Avoids the need to create your own list inside the
rule when you want to return multiple errors.