### PR TITLE
ref(prefer-unique-enums): don't require decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,8 @@ class Foo(enum.Enum):
 
 ### PIE796: prefer-unique-enums
 
-By default the stdlib enum allow multiple field names to map to the same
-value, this lint requires using the stdlib's `@enum.unique` decorator to
-ensure enum values are unique.
+By default the stdlib enum allows multiple field names to map to the same
+value, this lint requires each enum value be unique.
 
 ```python
 # error
@@ -307,13 +306,14 @@ class Foo(enum.Enum):
     A = "A"
     B = "B"
     C = "C"
+    D = "C"
 
 # ok
-@enum.unique
 class Foo(enum.Enum):
     A = "A"
     B = "B"
     C = "C"
+    D = "D"
 ```
 
 ### PIE797: no-unecessary-if-expr

--- a/flake8_pie/pie796_prefer_unique_enums.py
+++ b/flake8_pie/pie796_prefer_unique_enums.py
@@ -22,10 +22,35 @@ def _extends_enum(node: ast.ClassDef) -> bool:
 
 def pie786_prefer_unique_enum(node: ast.ClassDef, errors: list[Error]) -> None:
     if _extends_enum(node) and not node.decorator_list:
-        errors.append(PIE796(lineno=node.lineno, col_offset=node.col_offset))
+        seen: set[str | complex | None | bool] = set()
+        for stmt in node.body:
+            if isinstance(stmt, ast.Assign):
+                if isinstance(stmt.value, ast.Num):
+                    num_val = stmt.value.n
+                    if num_val in seen:
+                        errors.append(
+                            PIE796(lineno=stmt.lineno, col_offset=stmt.col_offset)
+                        )
+                    else:
+                        seen.add(num_val)
+                elif isinstance(stmt.value, ast.Str):
+                    str_val = stmt.value.s
+                    if str_val in seen:
+                        errors.append(
+                            PIE796(lineno=stmt.lineno, col_offset=stmt.col_offset)
+                        )
+                    else:
+                        seen.add(str_val)
+                elif isinstance(stmt.value, ast.NameConstant):
+                    name_val: None | bool = stmt.value.value
+                    if name_val in seen:
+                        errors.append(
+                            PIE796(lineno=stmt.lineno, col_offset=stmt.col_offset)
+                        )
+                    else:
+                        seen.add(name_val)
 
 
 PIE796 = partial(
-    Error,
-    message="PIE796: prefer-unique-enums: Consider using the @enum.unique decorator.",
+    Error, message="PIE796: prefer-unique-enums: Consider using removing dupe values."
 )

--- a/flake8_pie/tests/test_pie796_prefer_unique_enums.py
+++ b/flake8_pie/tests/test_pie796_prefer_unique_enums.py
@@ -15,27 +15,56 @@ PREFER_UNIQUE_ENUM_EXAMPLES = [
 class FakeEnum(enum.Enum):
     A = "A"
     B = "B"
-    C = "C"
+    C = "B"
 """,
-        errors=[PIE796(lineno=2, col_offset=0)],
+        errors=[PIE796(lineno=5, col_offset=4)],
     ),
     ex(
         code="""
 class FakeEnum(Enum):
     A = 1
     B = 2
-    C = 3
+    C = 2
 """,
-        errors=[PIE796(lineno=2, col_offset=0)],
+        errors=[PIE796(lineno=5, col_offset=4)],
     ),
     ex(
         code="""
 class FakeEnum(str, Enum):
+    A = "1"
+    B = "2"
+    C = "2"
+""",
+        errors=[PIE796(lineno=5, col_offset=4)],
+    ),
+    ex(
+        code="""
+class FakeEnum(Enum):
+    A = 1.0
+    B = 2.5
+    C = 2.5
+""",
+        errors=[PIE796(lineno=5, col_offset=4)],
+    ),
+    ex(
+        code="""
+class FakeEnum(Enum):
+    A = 1.0
+    B = True
+    C = False
+    D = False
+""",
+        errors=[PIE796(lineno=4, col_offset=4), PIE796(lineno=6, col_offset=4)],
+    ),
+    ex(
+        code="""
+class FakeEnum(Enum):
     A = 1
     B = 2
-    C = 3
+    C = None
+    D = None
 """,
-        errors=[PIE796(lineno=2, col_offset=0)],
+        errors=[PIE796(lineno=6, col_offset=4)],
     ),
     ex(
         code="""
@@ -53,7 +82,7 @@ class FakeEnum(enum.Enum):
 class FakeEnum(Enum):
     A = 1
     B = 2
-    C = 3
+    C = 2
 """,
         errors=[],
     ),
@@ -63,13 +92,12 @@ class FakeEnum(Enum):
 class FakeEnum(enum.Enum):
     A = "A"
     B = "B"
-    C = "C"
+    C = "B"
 """,
         errors=[],
     ),
     ex(
         code="""
-@foo_decorator
 class FakeEnum(enum.Enum):
     A = "A"
     B = "B"


### PR DESCRIPTION
Instead of requiring the decorator, check that the enum values are unqiue.