### PR TITLE
update(rule/prefer-dataclass): make heuristic more strict

### DIFF
--- a/flake8_pie/pie793_prefer_dataclass.py
+++ b/flake8_pie/pie793_prefer_dataclass.py
@@ -7,11 +7,9 @@ from typing import Sequence
 from flake8_pie.base import Error
 
 
-def _is_suspicious_assignment_stmt(stmt: ast.stmt) -> bool:
-    return (
-        isinstance(stmt, ast.AnnAssign)
-        and isinstance(stmt.target, ast.Name)
-        and stmt.target.id != "__slots__"
+def _is_dataclass_like_stmt(stmt: ast.stmt) -> bool:
+    return isinstance(stmt, ast.AnnAssign) or (
+        isinstance(stmt, ast.FunctionDef) and stmt.name == "__init__"
     )
 
 
@@ -25,7 +23,7 @@ def pie793_prefer_dataclass(
         not inside_inheriting_cls
         and not node.bases
         and not node.decorator_list
-        and any(_is_suspicious_assignment_stmt(stmt) for stmt in node.body)
+        and all(_is_dataclass_like_stmt(stmt) for stmt in node.body)
     ):
         errors.append(PIE793(lineno=node.lineno, col_offset=node.col_offset))
 

--- a/flake8_pie/tests/test_pie793_prefer_dataclass.py
+++ b/flake8_pie/tests/test_pie793_prefer_dataclass.py
@@ -42,12 +42,20 @@ class Foo:
     ),
     ex(
         code="""
+class Foo:
+    x: list[str]
+    def __init__(self) -> None: ...
+""",
+        errors=[PIE793(lineno=2, col_offset=0)],
+    ),
+    ex(
+        code="""
 class FakeEnum:
     A: int = 1
     B = 2
     C = 3
 """,
-        errors=[PIE793(lineno=2, col_offset=0)],
+        errors=[],
     ),
     ex(
         code="""
@@ -94,6 +102,15 @@ class Foo:
 @dataclass
 class Foo:
     x: list[str]
+""",
+        errors=[],
+    ),
+    ex(
+        code="""
+class Foo:
+    x: list[str]
+    async def create(self) -> Foo:
+        raise NotImplementedError
 """,
         errors=[],
     ),


### PR DESCRIPTION
Essentially make this rule less likely to trigger, the goal of the rule
is to find cases where you're missing a `@dataclass` but the heuristic
was a little too loose and gave a number of false positives in Kodiak.