### PR TITLE
update(rule): no-pointless-statements check for pointless super

### DIFF
--- a/flake8_pie/pie791_no_pointless_statements.py
+++ b/flake8_pie/pie791_no_pointless_statements.py
@@ -7,7 +7,11 @@ from flake8_pie.base import Error
 
 
 def pie791_no_pointless_statements(node: ast.Expr, errors: list[Error]) -> None:
-    if isinstance(node.value, ast.Compare):
+    if isinstance(node.value, ast.Compare) or (
+        isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "super"
+    ):
         errors.append(PIE791(lineno=node.lineno, col_offset=node.col_offset))
 
 

--- a/flake8_pie/tests/test_pie791_no_pointless_statements.py
+++ b/flake8_pie/tests/test_pie791_no_pointless_statements.py
@@ -47,6 +47,14 @@ res.json() == []
         ),
         ex(
             code="""
+class Foo:
+    def __init__(self) -> None:
+        super()
+""",
+            errors=[PIE791(lineno=4, col_offset=8)],
+        ),
+        ex(
+            code="""
 is_eql = res.json() == []
 """,
             errors=[],
@@ -66,6 +74,27 @@ data = "foo"
         ex(
             code="""
 process(data == "foo")
+""",
+            errors=[],
+        ),
+        ex(
+            code="""
+class Foo:
+    def __init__(self) -> None:
+        super().__init__()
+""",
+            errors=[],
+        ),
+        ex(
+            code="""
+class SomeView(BaseView):
+    def list(self, request: Request) -> Response:
+        data = (
+            super()
+            .get_queryset()
+            .filter(x__gt=10)
+        )
+        return Response(data)
 """,
             errors=[],
         ),

--- a/s/shell
+++ b/s/shell
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex
+
+./.venv/bin/ipython


### PR DESCRIPTION
Coming from JS one might think calling `super()` inside an `__init__`
method does something, but it's a no-op.

Might need to make this rule more specific since it checks for any calls 
with name `super()`.