### PR TITLE
add(rule): no-unnecessary-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,36 @@ foo(is_valid=True if buzz() else False)
 foo(is_valid=bool(buzz()))
 ```
 
+### PIE798: no-unecessary-class
+
+Instead of using class to namespace functions, use a module.
+
+```python
+# error
+class UserManager:
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+
+# ok
+class User(NamedTuple):
+    name: str
+
+def update_user(user: User) -> None:
+    ...
+
+@staticmethod
+def sync_users() -> None:
+    ...
+```
+
 ## dev
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ class Foo(enum.Enum):
     D = "D"
 ```
 
-### PIE797: no-unecessary-if-expr
+### PIE797: no-unnecessary-if-expr
 
 Call `bool()` directly rather than reimplementing its functionality.
 
@@ -326,7 +326,7 @@ foo(is_valid=True if buzz() else False)
 foo(is_valid=bool(buzz()))
 ```
 
-### PIE798: no-unecessary-class
+### PIE798: no-unnecessary-class
 
 Instead of using class to namespace functions, use a module.
 
@@ -351,7 +351,6 @@ class User(NamedTuple):
 def update_user(user: User) -> None:
     ...
 
-@staticmethod
 def sync_users() -> None:
     ...
 ```

--- a/flake8_pie/__init__.py
+++ b/flake8_pie/__init__.py
@@ -26,6 +26,7 @@ from flake8_pie.pie794_dupe_class_field_definitions import (
 from flake8_pie.pie795_prefer_stdlib_enums import pie795_prefer_stdlib_enums
 from flake8_pie.pie796_prefer_unique_enums import pie786_prefer_unique_enum
 from flake8_pie.pie797_no_unnecessary_if_expr import pie797_no_unnecessary_if_expr
+from flake8_pie.pie798_no_unnecessary_class import pie798_no_unnecessary_class
 
 
 class Flake8PieVisitor(ast.NodeVisitor):
@@ -48,6 +49,7 @@ class Flake8PieVisitor(ast.NodeVisitor):
         pie793_prefer_dataclass(node, self.errors, self.inside_inheriting_cls_stack)
         pie795_prefer_stdlib_enums(node, self.errors, self.inside_inheriting_cls_stack)
         pie786_prefer_unique_enum(node, self.errors)
+        pie798_no_unnecessary_class(node, self.errors)
 
         is_inheriting_cls = len(node.bases) > 0
         self.inside_inheriting_cls_stack.append(is_inheriting_cls)

--- a/flake8_pie/pie798_no_unnecessary_class.py
+++ b/flake8_pie/pie798_no_unnecessary_class.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import ast
+from functools import partial
+
+from flake8_pie.base import Error
+
+ALLOW_DECORATORS = {"staticmethod", "classmethod"}
+
+
+def _is_possible_instance_method(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    if func.args.args and func.args.args[0].arg == "self":
+        return True
+
+    if func.decorator_list and any(
+        not isinstance(dec, ast.Name) or dec.id not in ALLOW_DECORATORS
+        for dec in func.decorator_list
+    ):
+        return True
+
+    return False
+
+
+def pie798_no_unnecessary_class(node: ast.ClassDef, errors: list[Error]) -> None:
+    if node.bases:
+        return
+    if not node.body:
+        return
+
+    has_func_defined = False
+    for stmt in node.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            has_func_defined = True
+            if _is_possible_instance_method(stmt):
+                return
+        elif isinstance(stmt, (ast.AnnAssign, ast.Assign)):
+            return
+
+    if has_func_defined:
+        errors.append(PIE798(lineno=node.lineno, col_offset=node.col_offset))
+
+
+PIE798 = partial(
+    Error,
+    message="PIE798: no-unnecessary-class: Consider using a module for namespacing instead.",
+)

--- a/flake8_pie/tests/test_pie798_no_unnecessary_class.py
+++ b/flake8_pie/tests/test_pie798_no_unnecessary_class.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from flake8_pie import Flake8PieCheck
+from flake8_pie.pie798_no_unnecessary_class import PIE798
+from flake8_pie.tests.utils import Error, ex, to_errors
+
+EXAMPLES = [
+    ex(
+        code="""
+class UserManager:
+    '''
+    some class
+    '''
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[PIE798(lineno=2, col_offset=0)],
+    ),
+    ex(
+        # ignore any classes inheriting from something
+        code="""
+class UserManager(Foo):
+    '''
+    some class
+    '''
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore any classes with extra decorators on method
+        code="""
+class UserManager:
+    '''
+    some class
+    '''
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @bar
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore any classes with a property defined w/ type
+        code="""
+class UserManager:
+    x: int
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore any classes with a property defined
+        code="""
+class UserManager:
+    x = None
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore classes with self as a param
+        code="""
+class UserManager:
+    async def foo(self) -> None:
+        ...
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore classes with __init__
+        code="""
+class UserManager:
+    def __init__(self) -> None:
+        ...
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore classes with any method that takes `self`
+        code="""
+class UserManager:
+    def foo(self) -> None:
+        ...
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        # ignore classes with any method that takes `self`
+        code="""
+class UserManager:
+    def foo(self) -> None:
+        ...
+
+    class User(NamedTuple):
+        name: str
+
+    @classmethod
+    def update_user(cls, user: User) -> None:
+        ...
+
+    @staticmethod
+    def sync_users() -> None:
+        ...
+""",
+        errors=[],
+    ),
+    ex(
+        code="""
+'''
+some class
+'''
+
+class User(NamedTuple):
+    name: str
+
+def update_user(user: User) -> None:
+    ...
+
+def sync_users() -> None:
+    ...
+""",
+        errors=[],
+    ),
+]
+
+
+@pytest.mark.parametrize("code,errors", EXAMPLES)
+def test_no_unnecessary_class(code: str, errors: list[Error]) -> None:
+    expr = ast.parse(code)
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors


### PR DESCRIPTION
Coming from a language without modules / free functions you might end
up putting all your functions inside of a class as `static` / `class`
methods.

Instead in python we can create a module and use that if we want
namespacing.