### PR TITLE
fix(rules): generalize visiting ast stmt bodies

### DIFF
--- a/flake8_pie/base.py
+++ b/flake8_pie/base.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import ast
 from typing import NamedTuple
+
+from typing_extensions import Protocol
+
+
+class Body(Protocol):
+    body: list[ast.stmt]
 
 
 class Flake8Error(NamedTuple):

--- a/flake8_pie/pie781_assign_and_return.py
+++ b/flake8_pie/pie781_assign_and_return.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import Error
+from flake8_pie.base import Body, Error
 
 
 def _get_assign_target_id(stmt: ast.stmt) -> str | None:
@@ -25,7 +25,7 @@ def _get_assign_target_id(stmt: ast.stmt) -> str | None:
     return None
 
 
-def pie781_assign_and_return(func: ast.FunctionDef, errors: list[Error]) -> None:
+def pie781_assign_and_return(func: Body, errors: list[Error]) -> None:
     """
     check a FunctionDef for assignment and return where a user assigns to a
     variable and returns that variable instead of just returning

--- a/flake8_pie/pie790_no_unnecessary_pass.py
+++ b/flake8_pie/pie790_no_unnecessary_pass.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import ast
 from functools import partial
 
-from flake8_pie.base import Error
+from flake8_pie.base import Body, Error
 
 
-def pie790_no_unnecessary_pass(
-    node: ast.ClassDef | ast.FunctionDef, errors: list[Error]
-) -> None:
+def pie790_no_unnecessary_pass(node: Body, errors: list[Error]) -> None:
     if (
         len(node.body) > 1
         and isinstance(node.body[0], ast.Expr)

--- a/flake8_pie/tests/test_pie790_no_unnecessary_pass.py
+++ b/flake8_pie/tests/test_pie790_no_unnecessary_pass.py
@@ -32,6 +32,79 @@ def foo() -> None:
             errors=[PIE790(lineno=7, col_offset=4)],
         ),
         ex(
+            code='''
+async def foo():
+    """
+    buzz
+    """
+
+    pass
+''',
+            errors=[PIE790(lineno=7, col_offset=4)],
+        ),
+        ex(
+            code='''
+try:
+    """
+    buzz
+    """
+    pass
+except ValueError:
+    pass
+''',
+            errors=[PIE790(lineno=6, col_offset=4)],
+        ),
+        ex(
+            code="""
+try:
+    bar()
+except ValueError:
+    '''bar'''
+    pass
+""",
+            errors=[PIE790(lineno=6, col_offset=4)],
+        ),
+        ex(
+            code="""
+for _ in range(10):
+    '''buzz'''
+    pass
+""",
+            errors=[PIE790(lineno=4, col_offset=4)],
+        ),
+        ex(
+            code="""
+async for _ in range(10):
+    '''buzz'''
+    pass
+""",
+            errors=[PIE790(lineno=4, col_offset=4)],
+        ),
+        ex(
+            code="""
+while cond:
+    '''buzz'''
+    pass
+""",
+            errors=[PIE790(lineno=4, col_offset=4)],
+        ),
+        ex(
+            code="""
+with bar:
+    '''buzz'''
+    pass
+""",
+            errors=[PIE790(lineno=4, col_offset=4)],
+        ),
+        ex(
+            code="""
+async with bar:
+    '''buzz'''
+    pass
+""",
+            errors=[PIE790(lineno=4, col_offset=4)],
+        ),
+        ex(
             code="""
 class Foo:
     # bar


### PR DESCRIPTION
Added a method to the visitor that visits all the stmts with bodies, which
a few rules want, rather than targeting specific nodes.

This avoids us skipping over the bodies of various node types.