### PR TITLE
add(rule): no-unnecessary-dict-kwargs

### DIFF
--- a/flake8_pie/__init__.py
+++ b/flake8_pie/__init__.py
@@ -35,6 +35,7 @@ from flake8_pie.pie802_prefer_simple_any_all import pie802_prefer_simple_any_all
 from flake8_pie.pie803_prefer_logging_interpolation import (
     pie803_prefer_logging_interpolation,
 )
+from flake8_pie.pie804_no_unnecessary_dict_kwargs import pie804_no_dict_kwargs
 
 
 @dataclass(frozen=True)
@@ -92,6 +93,7 @@ class Flake8PieVisitor(ast.NodeVisitor):
         pie785_celery_require_tasks_expire(node, self.errors)
         pie802_prefer_simple_any_all(node, self.errors)
         pie803_prefer_logging_interpolation(node, self.errors)
+        pie804_no_dict_kwargs(node, self.errors)
 
         self.generic_visit(node)
 

--- a/flake8_pie/pie804_no_unnecessary_dict_kwargs.py
+++ b/flake8_pie/pie804_no_unnecessary_dict_kwargs.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import ast
+import string
+
+from flake8_pie.base import Error
+
+DIGITS = frozenset(string.digits)
+VALID_IDENT_CHARS = DIGITS | frozenset(string.ascii_letters) | {"_"}
+
+
+def is_valid_kwarg_name(name: str) -> bool:
+    """
+    see: https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+    """
+    if not name:
+        return False
+    if name[0] in DIGITS:
+        return False
+    return all(c in VALID_IDENT_CHARS for c in name)
+
+
+def pie804_no_dict_kwargs(node: ast.Call, errors: list[Error]) -> None:
+    for kw in node.keywords:
+        if (
+            kw.arg is None
+            and isinstance(kw.value, ast.Dict)
+            and all(
+                isinstance(key, ast.Str) and is_valid_kwarg_name(key.s)
+                for key in kw.value.keys
+            )
+        ):
+            errors.append(
+                PIE804(lineno=kw.value.lineno, col_offset=kw.value.col_offset)
+            )
+
+
+def PIE804(lineno: int, col_offset: int) -> Error:
+    return Error(
+        lineno=lineno,
+        col_offset=col_offset,
+        message="PIE804: no-unnecessary-dict-kwargs: Remove the dict and pass the kwargs directly.",
+    )

--- a/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
+++ b/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
@@ -17,6 +17,12 @@ foo(**{"bar": True})
     ),
     ex(
         code="""
+foo(**{"r2d2": True})
+""",
+        errors=[PIE804(lineno=2, col_offset=6)],
+    ),
+    ex(
+        code="""
 Foo.objects.create(**{"bar": True})
 """,
         errors=[PIE804(lineno=2, col_offset=21)],

--- a/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
+++ b/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
@@ -41,6 +41,7 @@ foo(**{"bar foo": True})
 foo(**{"1foo": True})
 foo(**{buzz: True})
 foo(**{"": True})
+foo(**{f"buzz__{bar}": True})
 """,
         errors=[],
     ),

--- a/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
+++ b/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from flake8_pie import Flake8PieCheck
+from flake8_pie.pie804_no_unnecessary_dict_kwargs import PIE804
+from flake8_pie.tests.utils import Error, ex, to_errors
+
+EXAMPLES = [
+    ex(
+        code="""
+foo(**{"bar": True})
+""",
+        errors=[PIE804(lineno=2, col_offset=6)],
+    ),
+    ex(
+        code="""
+Foo.objects.create(**{"bar": True})
+""",
+        errors=[PIE804(lineno=2, col_offset=21)],
+    ),
+    ex(
+        code="""
+Foo.objects.create(**{"_id": some_id})
+""",
+        errors=[PIE804(lineno=2, col_offset=21)],
+    ),
+    ex(
+        code="""
+foo(**buzz)
+foo(**{"bar-foo": True})
+foo(**{"bar foo": True})
+foo(**{"1foo": True})
+foo(**{buzz: True})
+foo(**{"": True})
+""",
+        errors=[],
+    ),
+]
+
+
+@pytest.mark.parametrize("code,errors", EXAMPLES)
+def test_examples(code: str, errors: list[Error]) -> None:
+    expr = ast.parse(code)
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors


### PR DESCRIPTION
You'll rarely actually need to wrap kwargs in a dict and spread.
Passing the kwargs directly is simpler and can benefit from type checking.

fixes: https://github.com/sbdchd/flake8-pie/issues/80