### PR TITLE
ref(no-unnecessary-dict-kwargs): handle unnecessary spread in args

### DIFF
--- a/flake8_pie/pie804_no_unnecessary_dict_kwargs.py
+++ b/flake8_pie/pie804_no_unnecessary_dict_kwargs.py
@@ -25,9 +25,12 @@ def pie804_no_dict_kwargs(node: ast.Call, errors: list[Error]) -> None:
         if (
             kw.arg is None
             and isinstance(kw.value, ast.Dict)
-            and all(
-                isinstance(key, ast.Str) and is_valid_kwarg_name(key.s)
-                for key in kw.value.keys
+            and (
+                all(
+                    isinstance(key, ast.Str) and is_valid_kwarg_name(key.s)
+                    for key in kw.value.keys
+                )
+                or (len(kw.value.keys) == 1 and kw.value.keys[0] is None)
             )
         ):
             errors.append(

--- a/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
+++ b/flake8_pie/tests/test_pie804_no_unnecessary_dict_kwargs.py
@@ -35,6 +35,13 @@ Foo.objects.create(**{"_id": some_id})
     ),
     ex(
         code="""
+Foo.objects.create(**{**bar})
+""",
+        errors=[PIE804(lineno=2, col_offset=21)],
+    ),
+    ex(
+        code="""
+foo(**{**data, "foo": "buzz"})
 foo(**buzz)
 foo(**{"bar-foo": True})
 foo(**{"bar foo": True})


### PR DESCRIPTION
`foo(**{**bar})` is equivalent to `foo(**bar)`

fixes: https://github.com/sbdchd/flake8-pie/issues/92