### PR TITLE
add(rule): prefer literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Currently only checks for byte string literals.
 
 # ok
 b"foo"
+"😀".encode()
 ```
 
 ## uploading a new version to [PyPi](https://pypi.org)

--- a/README.md
+++ b/README.md
@@ -477,6 +477,18 @@ s/lint
 s/test
 ```
 
+### PIE805: prefer-literal
+
+Currently only checks for byte string literals.
+
+```python
+# error
+"foo".encode()
+
+# ok
+b"foo"
+```
+
 ## uploading a new version to [PyPi](https://pypi.org)
 
 ```shell

--- a/flake8_pie/__init__.py
+++ b/flake8_pie/__init__.py
@@ -36,6 +36,7 @@ from flake8_pie.pie803_prefer_logging_interpolation import (
     pie803_prefer_logging_interpolation,
 )
 from flake8_pie.pie804_no_unnecessary_dict_kwargs import pie804_no_dict_kwargs
+from flake8_pie.pie805_prefer_literal import pie805_prefer_literal
 
 
 @dataclass(frozen=True)
@@ -94,6 +95,7 @@ class Flake8PieVisitor(ast.NodeVisitor):
         pie802_prefer_simple_any_all(node, self.errors)
         pie803_prefer_logging_interpolation(node, self.errors)
         pie804_no_dict_kwargs(node, self.errors)
+        pie805_prefer_literal(node, self.errors)
 
         self.generic_visit(node)
 

--- a/flake8_pie/pie805_prefer_literal.py
+++ b/flake8_pie/pie805_prefer_literal.py
@@ -20,6 +20,7 @@ def pie805_prefer_literal(node: ast.Call, errors: list[Error]) -> None:
                 and node.args[0].s in UTF8_ENCODE_NAMES
             )
         )
+        and node.func.value.s.isascii()
     ):
         literal_str_node = node.func.value
         errors.append(

--- a/flake8_pie/pie805_prefer_literal.py
+++ b/flake8_pie/pie805_prefer_literal.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ast
+
+from flake8_pie.base import Error
+
+UTF8_ENCODE_NAMES = frozenset({"utf8", "utf-8"})
+
+
+def pie805_prefer_literal(node: ast.Call, errors: list[Error]) -> None:
+    if (
+        isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Str)
+        and node.func.attr == "encode"
+        and (
+            len(node.args) == 0
+            or (
+                len(node.args) == 1
+                and isinstance(node.args[0], ast.Str)
+                and node.args[0].s in UTF8_ENCODE_NAMES
+            )
+        )
+    ):
+        literal_str_node = node.func.value
+        errors.append(
+            PIE805(
+                lineno=literal_str_node.lineno, col_offset=literal_str_node.col_offset
+            )
+        )
+
+
+def PIE805(lineno: int, col_offset: int) -> Error:
+    return Error(
+        lineno=lineno,
+        col_offset=col_offset,
+        message="PIE805: prefer-literal: Prefer the byte string literal rather than calling encode.",
+    )

--- a/flake8_pie/tests/test_pie805_prefer_literal.py
+++ b/flake8_pie/tests/test_pie805_prefer_literal.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from flake8_pie import Flake8PieCheck
+from flake8_pie.pie805_prefer_literal import PIE805
+from flake8_pie.tests.utils import Error, ex, to_errors
+
+EXAMPLES = [
+    ex(
+        code="""
+"foo".encode()
+""",
+        errors=[PIE805(lineno=2, col_offset=0)],
+    ),
+    ex(
+        code="""
+"foo".encode("utf-8")
+""",
+        errors=[PIE805(lineno=2, col_offset=0)],
+    ),
+    ex(
+        code="""
+"foo".encode("utf8")
+""",
+        errors=[PIE805(lineno=2, col_offset=0)],
+    ),
+    ex(
+        code="""
+b"foo"
+"foo".encode("ascii")
+"foo".encode("bar")
+""",
+        errors=[],
+    ),
+]
+
+
+@pytest.mark.parametrize("code,errors", EXAMPLES)
+def test_examples(code: str, errors: list[Error]) -> None:
+    expr = ast.parse(code)
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors

--- a/flake8_pie/tests/test_pie805_prefer_literal.py
+++ b/flake8_pie/tests/test_pie805_prefer_literal.py
@@ -32,6 +32,7 @@ EXAMPLES = [
 b"foo"
 "foo".encode("ascii")
 "foo".encode("bar")
+"😀".encode()
 """,
         errors=[],
     ),


### PR DESCRIPTION
Currently this only checks for byte strings, but I imagine we may expand
it later, hence the rather generic name.

https://github.com/sbdchd/flake8-pie/issues/91