### PR TITLE
add(rule): prefer-simple-range

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,21 @@ class Foo:
     foo: List[str] = field(default_factory=list)
 ```
 
+### PIE808: prefer-simple-range
+
+We can leave out the first argument to `range` in some cases since the default
+start position is 0.
+
+```python
+# err
+range(0, 10)
+
+# ok
+range(10)
+range(x, 10)
+range(0, 10, x)
+```
+
 ## uploading a new version to [PyPi](https://pypi.org)
 
 ```shell

--- a/flake8_pie/__init__.py
+++ b/flake8_pie/__init__.py
@@ -39,6 +39,7 @@ from flake8_pie.pie804_no_unnecessary_dict_kwargs import pie804_no_dict_kwargs
 from flake8_pie.pie805_prefer_literal import pie805_prefer_literal
 from flake8_pie.pie806_no_assert_except import pie806_no_assert_except
 from flake8_pie.pie807_pefer_list_builtin import pie807_prefer_list_builtin
+from flake8_pie.pie808_prefer_simple_range import pie808_prefer_simple_range
 
 
 @dataclass(frozen=True)
@@ -98,6 +99,7 @@ class Flake8PieVisitor(ast.NodeVisitor):
         pie803_prefer_logging_interpolation(node, self.errors)
         pie804_no_dict_kwargs(node, self.errors)
         pie805_prefer_literal(node, self.errors)
+        pie808_prefer_simple_range(node, self.errors)
 
         self.generic_visit(node)
 

--- a/flake8_pie/pie808_prefer_simple_range.py
+++ b/flake8_pie/pie808_prefer_simple_range.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import ast
+
+from flake8_pie.base import Error
+
+
+def pie808_prefer_simple_range(node: ast.Call, errors: list[Error]) -> None:
+    if (
+        isinstance(node.func, ast.Name)
+        and node.func.id == "range"
+        and len(node.args) == 2
+        and isinstance(node.args[0], ast.Num)
+        and node.args[0].n == 0
+    ):
+        errors.append(
+            err(lineno=node.args[0].lineno, col_offset=node.args[0].col_offset)
+        )
+
+
+def err(lineno: int, col_offset: int) -> Error:
+    return Error(
+        lineno=lineno,
+        col_offset=col_offset,
+        message="PIE808: prefer-simple-range: range starts at 0 by default.",
+    )

--- a/flake8_pie/tests/test_pie808_prefer_simple_range.py
+++ b/flake8_pie/tests/test_pie808_prefer_simple_range.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from flake8_pie import Flake8PieCheck
+from flake8_pie.pie808_prefer_simple_range import err
+from flake8_pie.tests.utils import Error, ex, to_errors
+
+EXAMPLES = [
+    ex(
+        code="""
+range(0, 10)
+""",
+        errors=[err(lineno=2, col_offset=6)],
+    ),
+    ex(
+        code="""
+range(x, 10)
+range(-15, 10)
+range(10)
+range(0, 10, x)
+""",
+        errors=[],
+    ),
+]
+
+
+@pytest.mark.parametrize("code,errors", EXAMPLES)
+def test_examples(code: str, errors: list[Error]) -> None:
+    expr = ast.parse(code)
+    assert to_errors(Flake8PieCheck(expr, filename="foo.py").run()) == errors


### PR DESCRIPTION
We can leave off the first arg of range in some cases since the default
start position is 0.